### PR TITLE
perf: Move the logic for determining which handler to use to the conditioalHandler to the conditional_handler.go

### DIFF
--- a/telegohandler/bot_handler_test.go
+++ b/telegohandler/bot_handler_test.go
@@ -49,7 +49,7 @@ func TestNewBotHandler(t *testing.T) {
 
 		assert.Equal(t, bot, bh.bot)
 		assert.EqualValues(t, updates, bh.updates)
-		assert.Equal(t, []conditionalHandler{}, bh.handlers)
+		assert.Equal(t, []*conditionalHandler{}, bh.handlers)
 		assert.Nil(t, bh.stop)
 	})
 
@@ -59,7 +59,7 @@ func TestNewBotHandler(t *testing.T) {
 
 		assert.Equal(t, bot, bh.bot)
 		assert.EqualValues(t, updates, bh.updates)
-		assert.Equal(t, []conditionalHandler{}, bh.handlers)
+		assert.Equal(t, []*conditionalHandler{}, bh.handlers)
 		assert.Nil(t, bh.stop)
 	})
 
@@ -256,7 +256,7 @@ func TestBotHandler_Handle(t *testing.T) {
 		assert.NotNil(t, bh.handlers[0].Handler)
 		assert.Nil(t, bh.handlers[0].Predicates)
 
-		bh.handlers = make([]conditionalHandler, 0)
+		bh.handlers = make([]*conditionalHandler, 0)
 	})
 
 	predicate := Predicate(func(update telego.Update) bool { return false })
@@ -268,7 +268,7 @@ func TestBotHandler_Handle(t *testing.T) {
 		assert.NotNil(t, bh.handlers[0].Handler)
 		assert.NotNil(t, bh.handlers[0].Predicates)
 
-		bh.handlers = make([]conditionalHandler, 0)
+		bh.handlers = make([]*conditionalHandler, 0)
 	})
 }
 

--- a/telegohandler/conditional_handler.go
+++ b/telegohandler/conditional_handler.go
@@ -1,0 +1,20 @@
+package telegohandler
+
+import "github.com/mymmrac/telego"
+
+type conditionalHandler struct {
+	Handler    Handler
+	Predicates []Predicate
+}
+
+// match Matches the current update and handler
+func (ch *conditionalHandler) match(update telego.Update) bool {
+	ok := true
+	for _, p := range ch.Predicates {
+		if !p(update) {
+			ok = false
+			break
+		}
+	}
+	return ok
+}


### PR DESCRIPTION
# :speech_balloon: Description

1. Separate conditionalHandler type
    - Move the logic for determining which handler to use to the conditioalHandler
    - BotHandler now stores a pointer to the conditionalHandler
2. Start() will over by return directly when called multiple times.

Make the handler part more extensible and avoid exceptions caused by starting the same BotHandler multiple times.

## :monocle_face: Type of change

> :warning: Please select options that are relevant, and delete others.

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update (changes in existing test cases)

# :clipboard: Checklist

> :warning: Please make sure to check all tasks.

- [x] My code follows the [style guidelines](../docs/CONTRIBUTING.md#art-style-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] Feature or fix that I was working on is in "[releasable](../docs/CONTRIBUTING.md#always-releasable)" state
