### PR TITLE
Remove unnecessary require.NotNil in TestBot_UpdatesViaWebhook

### DIFF
--- a/webhook_test.go
+++ b/webhook_test.go
@@ -190,7 +190,6 @@ func TestBot_UpdatesViaWebhook(t *testing.T) {
 			require.NoError(t, errHTTP)
 			require.NoError(t, resp.Body.Close())
 
-			require.NotNil(t, resp)
 			assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 
 			resp, errHTTP = http.Post(fmt.Sprintf("http://%s", addr), ta.ContentTypeJSON,
@@ -198,7 +197,6 @@ func TestBot_UpdatesViaWebhook(t *testing.T) {
 			require.NoError(t, errHTTP)
 			require.NoError(t, resp.Body.Close())
 
-			require.NotNil(t, resp)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 		}()
 


### PR DESCRIPTION
# :speech_balloon: Description

This PR removes unnecessary `require.NotNil(t, resp)` because `resp` is always not-nil if `errHTTP` is `nil`.

## :monocle_face: Type of change

[//]: # (Please select options that are relevant, and delete others)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes in comments, .md files or other docs)
- [x] Test update (changes in existing test cases)

# :clipboard: Checklist

[//]: # (Please make sure to check all tasks)

- [x] My code follows the [style guidelines](/docs/CONTRIBUTING.md#art-style-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] Feature or fix that I was working on is in "[releasable](/docs/CONTRIBUTING.md#always-releasable)" state
