### PR TITLE
Add predicate checks for message media content

### DIFF
--- a/telegohandler/predicates.go
+++ b/telegohandler/predicates.go
@@ -64,6 +64,69 @@ func AnyMessage() Predicate {
 	}
 }
 
+func anyMessageWithPhoto(message *telego.Message) bool {
+	return message.Photo != nil
+}
+
+func anyMessageWithAudio(message *telego.Message) bool {
+	return message.Audio != nil
+}
+
+func anyMessageWithVideo(message *telego.Message) bool {
+	return message.Video != nil
+}
+
+func anyMessageWithVideoNote(message *telego.Message) bool {
+	return message.VideoNote != nil
+}
+
+func anyMessageWithVoice(message *telego.Message) bool {
+	return message.Voice != nil
+}
+
+func anyMessageWithPaidMedia(message *telego.Message) bool {
+	return message.PaidMedia != nil
+}
+func anyMessageWithDocument(message *telego.Message) bool {
+	return message.Document != nil
+}
+
+func anyMessageWithContact(message *telego.Message) bool {
+	return message.Contact != nil
+}
+
+func anyMessageWithGame(message *telego.Message) bool {
+	return message.Game != nil
+}
+
+func anyMessageWithStory(message *telego.Message) bool {
+	return message.Story != nil
+}
+
+func anyMessageWithLocation(message *telego.Message) bool {
+	return message.Location != nil
+}
+
+func anyMessageWithPoll(message *telego.Message) bool {
+	return message.Poll != nil
+}
+
+func anyMessageWithDice(message *telego.Message) bool {
+	return message.Dice != nil
+}
+
+func anyMessageWithSticker(message *telego.Message) bool {
+	return message.Sticker != nil
+}
+
+// AnyMessageWithMedia is true when message contain any media content
+func AnyMessageWithMedia() Predicate {
+	return func(_ context.Context, update telego.Update) bool {
+		return (anyMessageWithPhoto(update.Message) || anyMessageWithAudio(update.Message) || anyMessageWithVideo(update.Message) || anyMessageWithVideoNote(update.Message) || anyMessageWithVoice(update.Message) || anyMessageWithPaidMedia(update.Message) || anyMessageWithDocument(update.Message) || anyMessageWithContact(update.Message) || anyMessageWithGame(update.Message) || anyMessageWithStory(update.Message) || anyMessageWithLocation(update.Message) || anyMessageWithPoll(update.Message) || anyMessageWithDice(update.Message) || anyMessageWithSticker(update.Message))
+	}
+
+}
+
 func anyMassageWithText(message *telego.Message) bool {
 	return message != nil && message.Text != ""
 }

--- a/telegohandler/predicates.go
+++ b/telegohandler/predicates.go
@@ -53,14 +53,14 @@ func Not(predicate Predicate) Predicate {
 	}
 }
 
-func anyMassage(message *telego.Message) bool {
+func anyMessage(message *telego.Message) bool {
 	return message != nil
 }
 
 // AnyMessage is true if the message isn't nil
 func AnyMessage() Predicate {
 	return func(_ context.Context, update telego.Update) bool {
-		return anyMassage(update.Message)
+		return anyMessage(update.Message)
 	}
 }
 

--- a/telegohandler/predicates_test.go
+++ b/telegohandler/predicates_test.go
@@ -23,6 +23,22 @@ const (
 	testBotUsername = "test_bot"
 )
 
+var (
+	testVideo     = &telego.Video{FileID: "file_id"}
+	testVideoNote = &telego.VideoNote{FileID: "file_id"}
+	testPhoto     = []telego.PhotoSize{telego.PhotoSize{FileID: "file_id"}}
+	testAudio     = &telego.Audio{FileID: "file_id"}
+	testVoice     = &telego.Voice{FileID: "file_id"}
+	testDocument  = &telego.Document{FileID: "file_id"}
+	testSticker   = &telego.Sticker{FileID: "file_id"}
+	testPoll      = &telego.Poll{ID: "id"}
+	testDice      = &telego.Dice{Emoji: "emoji", Value: 1}
+	testLocation  = &telego.Location{Latitude: 0.0, Longitude: 0.0}
+	testStory     = &telego.Story{ID: 1}
+	testGame      = &telego.Game{Title: "Test game"}
+	testContact   = &telego.Contact{PhoneNumber: "+1234567890"}
+)
+
 func TestPredicates(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -125,6 +141,84 @@ func TestPredicates(t *testing.T) {
 			predicate: AnyMessageWithFrom(),
 			update:    telego.Update{Message: &telego.Message{}},
 			matches:   false,
+		},
+		{
+			name:      "any_message_with_photo_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Photo: testPhoto}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_audio_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Audio: testAudio}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_video_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Video: testVideo}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_video_note_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{VideoNote: testVideoNote}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_voice_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Voice: testVoice}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_document_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Document: testDocument}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_sticker_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Sticker: testSticker}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_poll_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Poll: testPoll}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_dice_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Dice: testDice}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_location_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Location: testLocation}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_story_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Story: testStory}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_game_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Game: testGame}},
+			matches:   true,
+		},
+		{
+			name:      "any_message_with_contact_matches",
+			predicate: AnyMessageWithMedia(),
+			update:    telego.Update{Message: &telego.Message{Contact: testContact}},
+			matches:   true,
 		},
 		{
 			name:      "text_equal_matches",


### PR DESCRIPTION
# :speech_balloon: Description

[//]: # (Please include a summary of the change, if it was related to the issue specify it)

Add predicates for messages with media content. It allows set handlers for messages which contains certain type of content: photo, video, etc.

## :monocle_face: Type of change

[//]: # (Please select options that are relevant, and delete others)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug (typo) fix (non-breaking change)

# :clipboard: Checklist

[//]: # (Please make sure to check all tasks)

- [ ] My code follows the [style guidelines](/docs/CONTRIBUTING.md#art-style-guidelines) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] Feature or fix that I was working on is in "[releasable](/docs/CONTRIBUTING.md#always-releasable)" state
