### PR TITLE
fix: return api response error in caller implements

### DIFF
--- a/telegoapi/caller.go
+++ b/telegoapi/caller.go
@@ -66,7 +66,9 @@ func (a FastHTTPCaller) Call(ctx context.Context, url string, data *RequestData)
 	if err != nil {
 		return nil, fmt.Errorf("decode json: %w", err)
 	}
-
+	if apiResp.Error != nil {
+		return nil, apiResp.Error
+	}
 	return apiResp, nil
 }
 
@@ -108,7 +110,9 @@ func (h HTTPCaller) Call(ctx context.Context, url string, data *RequestData) (*R
 	if err != nil {
 		return nil, fmt.Errorf("decode json: %w", err)
 	}
-
+	if apiResp.Error != nil {
+		return nil, apiResp.Error
+	}
 	return apiResp, nil
 }
 


### PR DESCRIPTION
# :speech_balloon: Description

[//]: # (Please include a summary of the change, if it was related to the issue specify it)

We should return the api error in Caller implements, or handle `resp.Error` in the implementation of `RetryCaller`, otherwise retry logic will not be initiated by the error returned by the API

#262 

## :monocle_face: Type of change

[//]: # (Please select options that are relevant, and delete others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes in comments, .md files or other docs)
- [ ] Test update (changes in existing test cases)

# :clipboard: Checklist

[//]: # (Please make sure to check all tasks)

- [x] My code follows the [style guidelines](/docs/CONTRIBUTING.md#art-style-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] Feature or fix that I was working on is in "[releasable](/docs/CONTRIBUTING.md#always-releasable)" state
