### PR TITLE
Bot API v10.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,6 @@ Telego is distributed under [MIT licence](LICENSE).
 
 [TelegramBotAPI]: https://core.telegram.org/bots/api
 
-[TelegramVersionBadge]: https://img.shields.io/static/v1?label=Supported%20Telegram%20Bot%20API&color=29a1d4&logo=telegram&message=v9.6
+[TelegramVersionBadge]: https://img.shields.io/static/v1?label=Supported%20Telegram%20Bot%20API&color=29a1d4&logo=telegram&message=v10.0
 
-[TelegramLastVersion]: https://core.telegram.org/bots/api#april-3-2026
+[TelegramLastVersion]: https://core.telegram.org/bots/api#may-8-2026

--- a/internal/generator/main.go
+++ b/internal/generator/main.go
@@ -83,9 +83,14 @@ var typeStructsSetters = []string{
 	"InputMediaAudio",
 	"InputMediaPhoto",
 	"InputMediaVideo",
+	"InputMediaLivePhoto",
+	"InputMediaLocation",
+	"InputMediaSticker",
+	"InputMediaVenue",
 
 	"InputPaidMediaPhoto",
 	"InputPaidMediaVideo",
+	"InputPaidMediaLivePhoto",
 
 	"InputTextMessageContent",
 	"InputLocationMessageContent",

--- a/methods.go
+++ b/methods.go
@@ -1146,6 +1146,104 @@ func (b *Bot) SendVoice(ctx context.Context, params *SendVoiceParams) (*Message,
 	return message, nil
 }
 
+// SendLivePhotoParams - Represents parameters of sendLivePhoto method.
+type SendLivePhotoParams struct {
+	// BusinessConnectionID - Optional. Unique identifier of the business connection on behalf of which the
+	// message will be sent
+	BusinessConnectionID string `json:"business_connection_id,omitempty"`
+
+	// ChatID - Unique identifier for the target chat or username of the target channel (in the format
+	// @channel_username)
+	ChatID ChatID `json:"chat_id"`
+
+	// MessageThreadID - Optional. Unique identifier for the target message thread (topic) of a forum; for forum
+	// supergroups and private chats of bots with forum topic mode enabled only
+	MessageThreadID int `json:"message_thread_id,omitempty"`
+
+	// DirectMessagesTopicID - Optional. Identifier of the direct messages topic to which the message will be
+	// sent; required if the message is sent to a direct messages chat
+	DirectMessagesTopicID int64 `json:"direct_messages_topic_id,omitempty"`
+
+	// LivePhoto - Live photo video to send. The video must be no longer than 10 seconds and must not exceed 10
+	// MB in size. Pass a file_id as String to send a video that exists on the Telegram servers (recommended) or
+	// upload a new video using multipart/form-data. More information on Sending Files »
+	// (https://core.telegram.org/bots/api#sending-files). Sending live photos by a URL is currently unsupported.
+	LivePhoto InputFile `json:"live_photo"`
+
+	// Photo - The static photo to send. Pass a file_id as String to send a photo that exists on the Telegram
+	// servers (recommended) or upload a new video using multipart/form-data. More information on Sending Files »
+	// (https://core.telegram.org/bots/api#sending-files). Sending live photos by a URL is currently unsupported.
+	Photo InputFile `json:"photo"`
+
+	// Caption - Optional. Video caption (may also be used when resending videos by file_id), 0-1024 characters
+	// after entities parsing
+	Caption string `json:"caption,omitempty"`
+
+	// ParseMode - Optional. Mode for parsing entities in the video caption. See formatting options
+	// (https://core.telegram.org/bots/api#formatting-options) for more details.
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// CaptionEntities - Optional. A JSON-serialized list of special entities that appear in the caption, which
+	// can be specified instead of parse_mode
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+
+	// ShowCaptionAboveMedia - Optional. Pass True, if the caption must be shown above the message media
+	ShowCaptionAboveMedia bool `json:"show_caption_above_media,omitempty"`
+
+	// HasSpoiler - Optional. Pass True if the video needs to be covered with a spoiler animation
+	HasSpoiler bool `json:"has_spoiler,omitempty"`
+
+	// DisableNotification - Optional. Sends the message silently
+	// (https://telegram.org/blog/channels-2-0#silent-messages). Users will receive a notification with no sound.
+	DisableNotification bool `json:"disable_notification,omitempty"`
+
+	// ProtectContent - Optional. Protects the contents of the sent message from forwarding and saving
+	ProtectContent bool `json:"protect_content,omitempty"`
+
+	// AllowPaidBroadcast - Optional. Pass True to allow up to 1000 messages per second, ignoring broadcasting
+	// limits (https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once) for a fee
+	// of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance.
+	AllowPaidBroadcast bool `json:"allow_paid_broadcast,omitempty"`
+
+	// MessageEffectID - Optional. Unique identifier of the message effect to be added to the message; for
+	// private chats only
+	MessageEffectID string `json:"message_effect_id,omitempty"`
+
+	// SuggestedPostParameters - Optional. A JSON-serialized object containing the parameters of the suggested
+	// post to send; for direct messages chats only. If the message is sent as a reply to another suggested post,
+	// then that suggested post is automatically declined.
+	SuggestedPostParameters *SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
+
+	// ReplyParameters - Optional. Description of the message to reply to
+	ReplyParameters *ReplyParameters `json:"reply_parameters,omitempty"`
+
+	// ReplyMarkup - Optional. Additional interface options. A JSON-serialized object for an inline keyboard
+	// (https://core.telegram.org/bots/features#inline-keyboards), custom reply keyboard
+	// (https://core.telegram.org/bots/features#keyboards), instructions to remove a reply keyboard or to force a
+	// reply from the user.
+	ReplyMarkup ReplyMarkup `json:"reply_markup,omitempty"`
+}
+
+func (p *SendLivePhotoParams) fileParameters() map[string]ta.NamedReader {
+	fp := make(map[string]ta.NamedReader)
+
+	fp["live_photo"] = p.LivePhoto.File
+	fp["photo"] = p.Photo.File
+
+	return fp
+}
+
+// SendLivePhoto - Use this method to send live photos. On success, the sent Message
+// (https://core.telegram.org/bots/api#message) is returned.
+func (b *Bot) SendLivePhoto(ctx context.Context, params *SendLivePhotoParams) (*Message, error) {
+	var message *Message
+	err := b.performRequest(ctx, "sendLivePhoto", params, &message)
+	if err != nil {
+		return nil, fmt.Errorf("telego: sendLivePhoto: %w", err)
+	}
+	return message, nil
+}
+
 // SendVideoNoteParams - Represents parameters of sendVideoNote method.
 type SendVideoNoteParams struct {
 	// BusinessConnectionID - Optional. Unique identifier of the business connection on behalf of which the
@@ -1653,7 +1751,7 @@ type SendPollParams struct {
 	// It can be specified instead of question_parse_mode
 	QuestionEntities []MessageEntity `json:"question_entities,omitempty"`
 
-	// Options - A JSON-serialized list of 2-12 answer options
+	// Options - A JSON-serialized list of 1-12 answer options
 	Options []InputPollOption `json:"options"`
 
 	// IsAnonymous - Optional. True, if the poll needs to be anonymous, defaults to True
@@ -1679,6 +1777,16 @@ type SendPollParams struct {
 	// HideResultsUntilCloses - Optional. Pass True, if poll results must be shown only after the poll closes
 	HideResultsUntilCloses bool `json:"hide_results_until_closes,omitempty"`
 
+	// MembersOnly - Optional. Pass True, if voting is limited to users who have been members of the chat where
+	// the poll is being sent for more than 24 hours; for channel chats only
+	MembersOnly bool `json:"members_only,omitempty"`
+
+	// CountryCodes - Optional. A JSON-serialized list of 0-12 two-letter ISO 3166-1 alpha-2
+	// (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes indicating the countries from which users
+	// can vote in the poll; for channel chats only. Use "FT" as a country code to allow users with anonymous
+	// numbers to vote. If omitted or empty, then users from any country can participate in the poll.
+	CountryCodes []string `json:"country_codes,omitempty"`
+
 	// CorrectOptionIDs - Optional. A JSON-serialized list of monotonically increasing 0-based identifiers of
 	// the correct answer options, required for polls in quiz mode
 	CorrectOptionIDs []int `json:"correct_option_ids,omitempty"`
@@ -1694,6 +1802,9 @@ type SendPollParams struct {
 	// ExplanationEntities - Optional. A JSON-serialized list of special entities that appear in the poll
 	// explanation. It can be specified instead of explanation_parse_mode
 	ExplanationEntities []MessageEntity `json:"explanation_entities,omitempty"`
+
+	// ExplanationMedia - Optional. Media added to the quiz explanation
+	ExplanationMedia InputPollMedia `json:"explanation_media,omitempty"`
 
 	// OpenPeriod - Optional. Amount of time in seconds the poll will be active after creation, 5-2628000. Can't
 	// be used together with close_date.
@@ -1717,6 +1828,9 @@ type SendPollParams struct {
 	// DescriptionEntities - Optional. A JSON-serialized list of special entities that appear in the poll
 	// description, which can be specified instead of description_parse_mode
 	DescriptionEntities []MessageEntity `json:"description_entities,omitempty"`
+
+	// Media - Optional. Media added to the poll description
+	Media InputPollMedia `json:"media,omitempty"`
 
 	// DisableNotification - Optional. Sends the message silently
 	// (https://telegram.org/blog/channels-2-0#silent-messages). Users will receive a notification with no sound.
@@ -1742,6 +1856,30 @@ type SendPollParams struct {
 	// (https://core.telegram.org/bots/features#keyboards), instructions to remove a reply keyboard or to force a
 	// reply from the user
 	ReplyMarkup ReplyMarkup `json:"reply_markup,omitempty"`
+}
+
+func (p *SendPollParams) fileParameters() map[string]ta.NamedReader {
+	fp := make(map[string]ta.NamedReader)
+
+	collect := func(m fileCompatible) {
+		if isNil(m) {
+			return
+		}
+		for _, v := range m.fileParameters() {
+			if isNil(v) {
+				continue
+			}
+			fp[v.Name()] = v
+		}
+	}
+
+	collect(p.Media)
+	collect(p.ExplanationMedia)
+	for i := range p.Options {
+		collect(p.Options[i].Media)
+	}
+
+	return fp
 }
 
 // SendPoll - Use this method to send a native poll. On success, the sent Message
@@ -1874,8 +2012,9 @@ type SendMessageDraftParams struct {
 	// identifier are animated
 	DraftID int `json:"draft_id"`
 
-	// Text - Text of the message to be sent, 1-4096 characters after entities parsing
-	Text string `json:"text"`
+	// Text - Optional. Text of the message to be sent, 0-4096 characters after entities parsing. Pass an empty
+	// text to show a "Thinking…" placeholder.
+	Text string `json:"text,omitempty"`
 
 	// ParseMode - Optional. Mode for parsing entities in the message text. See formatting options
 	// (https://core.telegram.org/bots/api#formatting-options) for more details.
@@ -1981,6 +2120,60 @@ func (b *Bot) SetMessageReaction(ctx context.Context, params *SetMessageReaction
 	err := b.performRequest(ctx, "setMessageReaction", params)
 	if err != nil {
 		return fmt.Errorf("telego: setMessageReaction: %w", err)
+	}
+	return nil
+}
+
+// DeleteMessageReactionParams - Represents parameters of deleteMessageReaction method.
+type DeleteMessageReactionParams struct {
+	// ChatID - Unique identifier for the target chat or username of the target supergroup (in the format
+	// @username)
+	ChatID ChatID `json:"chat_id"`
+
+	// MessageID - Identifier of the target message
+	MessageID int `json:"message_id"`
+
+	// UserID - Optional. Identifier of the user whose reaction will be removed, if the reaction was added by a
+	// user
+	UserID int64 `json:"user_id,omitempty"`
+
+	// ActorChatID - Optional. Identifier of the chat whose reaction will be removed, if the reaction was added
+	// by a chat
+	ActorChatID int64 `json:"actor_chat_id,omitempty"`
+}
+
+// DeleteMessageReaction - Use this method to remove a reaction from a message in a group or a supergroup
+// chat. The bot must have the 'can_delete_messages' administrator right in the chat. Returns True on success.
+func (b *Bot) DeleteMessageReaction(ctx context.Context, params *DeleteMessageReactionParams) error {
+	err := b.performRequest(ctx, "deleteMessageReaction", params)
+	if err != nil {
+		return fmt.Errorf("telego: deleteMessageReaction: %w", err)
+	}
+	return nil
+}
+
+// DeleteAllMessageReactionsParams - Represents parameters of deleteAllMessageReactions method.
+type DeleteAllMessageReactionsParams struct {
+	// ChatID - Unique identifier for the target chat or username of the target supergroup (in the format
+	// @username)
+	ChatID ChatID `json:"chat_id"`
+
+	// UserID - Optional. Identifier of the user whose reactions will be removed, if the reactions were added by
+	// a user
+	UserID int64 `json:"user_id,omitempty"`
+
+	// ActorChatID - Optional. Identifier of the chat whose reactions will be removed, if the reactions were
+	// added by a chat
+	ActorChatID int64 `json:"actor_chat_id,omitempty"`
+}
+
+// DeleteAllMessageReactions - Use this method to remove up to 10000 recent reactions in a group or a
+// supergroup chat added by a given user or chat. The bot must have the 'can_delete_messages' administrator
+// right in the chat. Returns True on success.
+func (b *Bot) DeleteAllMessageReactions(ctx context.Context, params *DeleteAllMessageReactionsParams) error {
+	err := b.performRequest(ctx, "deleteAllMessageReactions", params)
+	if err != nil {
+		return fmt.Errorf("telego: deleteAllMessageReactions: %w", err)
 	}
 	return nil
 }
@@ -2788,10 +2981,14 @@ type GetChatAdministratorsParams struct {
 	// ChatID - Unique identifier for the target chat or username of the target supergroup or channel (in the
 	// format @channel_username)
 	ChatID ChatID `json:"chat_id"`
+
+	// ReturnBots - Optional. Pass True to additionally receive all bots that are administrators of the chat. By
+	// default, bots other than the current bot are omitted.
+	ReturnBots bool `json:"return_bots,omitempty"`
 }
 
-// GetChatAdministrators - Use this method to get a list of administrators in a chat, which aren't bots.
-// Returns an Array of ChatMember (https://core.telegram.org/bots/api#chatmember) objects.
+// GetChatAdministrators - Use this method to get a list of administrators in a chat. Returns an Array of
+// ChatMember (https://core.telegram.org/bots/api#chatmember) objects.
 func (b *Bot) GetChatAdministrators(ctx context.Context, params *GetChatAdministratorsParams) ([]ChatMember, error) {
 	var chatMembersData []chatMemberData
 	err := b.performRequest(ctx, "getChatAdministrators", params, &chatMembersData)
@@ -3270,6 +3467,68 @@ func (b *Bot) ReplaceManagedBotToken(ctx context.Context, params *ReplaceManaged
 		return nil, fmt.Errorf("telego: replaceManagedBotToken: %w", err)
 	}
 	return token, nil
+}
+
+// GetManagedBotAccessSettingsParams - Represents parameters of getManagedBotAccessSettings method.
+type GetManagedBotAccessSettingsParams struct {
+	// UserID - User identifier of the managed bot whose access settings will be returned
+	UserID int64 `json:"user_id"`
+}
+
+// GetManagedBotAccessSettings - Use this method to get the access settings of a managed bot. Returns a
+// BotAccessSettings (https://core.telegram.org/bots/api#botaccesssettings) object on success.
+func (b *Bot) GetManagedBotAccessSettings(ctx context.Context, params *GetManagedBotAccessSettingsParams) (*BotAccessSettings, error) {
+	var botAccessSettings *BotAccessSettings
+	err := b.performRequest(ctx, "getManagedBotAccessSettings", params, &botAccessSettings)
+	if err != nil {
+		return nil, fmt.Errorf("telego: getManagedBotAccessSettings: %w", err)
+	}
+	return botAccessSettings, nil
+}
+
+// SetManagedBotAccessSettingsParams - Represents parameters of setManagedBotAccessSettings method.
+type SetManagedBotAccessSettingsParams struct {
+	// UserID - User identifier of the managed bot whose access settings will be changed
+	UserID int64 `json:"user_id"`
+
+	// IsAccessRestricted - Pass True, if only selected users can access the bot. The bot's owner can always
+	// access it.
+	IsAccessRestricted bool `json:"is_access_restricted"`
+
+	// AddedUserIDs - Optional. A JSON-serialized list of up to 10 identifiers of users who will have access to
+	// the bot in addition to its owner. Ignored if is_access_restricted is false.
+	AddedUserIDs []int64 `json:"added_user_ids,omitempty"`
+}
+
+// SetManagedBotAccessSettings - Use this method to change the access settings of a managed bot. Returns True
+// on success.
+func (b *Bot) SetManagedBotAccessSettings(ctx context.Context, params *SetManagedBotAccessSettingsParams) error {
+	err := b.performRequest(ctx, "setManagedBotAccessSettings", params)
+	if err != nil {
+		return fmt.Errorf("telego: setManagedBotAccessSettings: %w", err)
+	}
+	return nil
+}
+
+// GetUserPersonalChatMessagesParams - Represents parameters of getUserPersonalChatMessages method.
+type GetUserPersonalChatMessagesParams struct {
+	// UserID - Unique identifier for the target user
+	UserID int64 `json:"user_id"`
+
+	// Limit - The maximum number of messages to return; 1-20
+	Limit int `json:"limit"`
+}
+
+// GetUserPersonalChatMessages - Use this method to get the last messages from the personal chat (i.e., the
+// chat currently added to their profile) of a given user. On success, an array of Message
+// (https://core.telegram.org/bots/api#message) objects is returned.
+func (b *Bot) GetUserPersonalChatMessages(ctx context.Context, params *GetUserPersonalChatMessagesParams) ([]Message, error) {
+	var messages []Message
+	err := b.performRequest(ctx, "getUserPersonalChatMessages", params, &messages)
+	if err != nil {
+		return nil, fmt.Errorf("telego: getUserPersonalChatMessages: %w", err)
+	}
+	return messages, nil
 }
 
 // SetMyCommandsParams - Represents parameters of setMyCommands method.
@@ -4528,14 +4787,14 @@ func (p *EditMessageMediaParams) fileParameters() map[string]ta.NamedReader {
 	return fp
 }
 
-// EditMessageMedia - Use this method to edit animation, audio, document, photo, or video messages, or to add
-// media to text messages. If a message is part of a message album, then it can be edited only to an audio for
-// audio albums, only to a document for document albums and to a photo or a video otherwise. When an inline
-// message is edited, a new file can't be uploaded; use a previously uploaded file via its file_id or specify a
-// URL. On success, if the edited message is not an inline message, the edited Message
-// (https://core.telegram.org/bots/api#message) is returned, otherwise True is returned. Note that business
-// messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48
-// hours from the time they were sent.
+// EditMessageMedia - Use this method to edit animation, audio, document, live photo, photo, or video
+// messages, or to add media to text messages. If a message is part of a message album, then it can be edited
+// only to an audio for audio albums, only to a document for document albums and to a photo, a live photo, or a
+// video otherwise. When an inline message is edited, a new file can't be uploaded; use a previously uploaded
+// file via its file_id or specify a URL. On success, if the edited message is not an inline message, the
+// edited Message (https://core.telegram.org/bots/api#message) is returned, otherwise True is returned. Note
+// that business messages that were not sent by the bot and do not contain an inline keyboard can only be
+// edited within 48 hours from the time they were sent.
 func (b *Bot) EditMessageMedia(ctx context.Context, params *EditMessageMediaParams) (*Message, error) {
 	var message *Message
 	var success *bool
@@ -5350,6 +5609,26 @@ func (b *Bot) AnswerInlineQuery(ctx context.Context, params *AnswerInlineQueryPa
 		return fmt.Errorf("telego: answerInlineQuery: %w", err)
 	}
 	return nil
+}
+
+// AnswerGuestQueryParams - Represents parameters of answerGuestQuery method.
+type AnswerGuestQueryParams struct {
+	// GuestQueryID - Unique identifier for the query to be answered
+	GuestQueryID string `json:"guest_query_id"`
+
+	// Result - A JSON-serialized object describing the message to be sent
+	Result InlineQueryResult `json:"result"`
+}
+
+// AnswerGuestQuery - Use this method to reply to a received guest message. On success, a SentGuestMessage
+// (https://core.telegram.org/bots/api#sentguestmessage) object is returned.
+func (b *Bot) AnswerGuestQuery(ctx context.Context, params *AnswerGuestQueryParams) (*SentGuestMessage, error) {
+	var sentGuestMessage *SentGuestMessage
+	err := b.performRequest(ctx, "answerGuestQuery", params, &sentGuestMessage)
+	if err != nil {
+		return nil, fmt.Errorf("telego: answerGuestQuery: %w", err)
+	}
+	return sentGuestMessage, nil
 }
 
 // SendInvoiceParams - Represents parameters of sendInvoice method.

--- a/methods_setters.go
+++ b/methods_setters.go
@@ -1108,6 +1108,115 @@ func (p *SendVoiceParams) WithReplyMarkup(replyMarkup ReplyMarkup) *SendVoicePar
 }
 
 // WithBusinessConnectionID adds business connection ID parameter
+func (p *SendLivePhotoParams) WithBusinessConnectionID(businessConnectionID string) *SendLivePhotoParams {
+	p.BusinessConnectionID = businessConnectionID
+	return p
+}
+
+// WithChatID adds chat ID parameter
+func (p *SendLivePhotoParams) WithChatID(chatID ChatID) *SendLivePhotoParams {
+	p.ChatID = chatID
+	return p
+}
+
+// WithMessageThreadID adds message thread ID parameter
+func (p *SendLivePhotoParams) WithMessageThreadID(messageThreadID int) *SendLivePhotoParams {
+	p.MessageThreadID = messageThreadID
+	return p
+}
+
+// WithDirectMessagesTopicID adds direct messages topic ID parameter
+func (p *SendLivePhotoParams) WithDirectMessagesTopicID(directMessagesTopicID int64) *SendLivePhotoParams {
+	p.DirectMessagesTopicID = directMessagesTopicID
+	return p
+}
+
+// WithLivePhoto adds live photo parameter
+func (p *SendLivePhotoParams) WithLivePhoto(livePhoto InputFile) *SendLivePhotoParams {
+	p.LivePhoto = livePhoto
+	return p
+}
+
+// WithPhoto adds photo parameter
+func (p *SendLivePhotoParams) WithPhoto(photo InputFile) *SendLivePhotoParams {
+	p.Photo = photo
+	return p
+}
+
+// WithCaption adds caption parameter
+func (p *SendLivePhotoParams) WithCaption(caption string) *SendLivePhotoParams {
+	p.Caption = caption
+	return p
+}
+
+// WithParseMode adds parse mode parameter
+func (p *SendLivePhotoParams) WithParseMode(parseMode string) *SendLivePhotoParams {
+	p.ParseMode = parseMode
+	return p
+}
+
+// WithCaptionEntities adds caption entities parameter
+func (p *SendLivePhotoParams) WithCaptionEntities(captionEntities ...MessageEntity) *SendLivePhotoParams {
+	p.CaptionEntities = captionEntities
+	return p
+}
+
+// WithShowCaptionAboveMedia adds show caption above media parameter
+func (p *SendLivePhotoParams) WithShowCaptionAboveMedia() *SendLivePhotoParams {
+	p.ShowCaptionAboveMedia = true
+	return p
+}
+
+// WithHasSpoiler adds has spoiler parameter
+func (p *SendLivePhotoParams) WithHasSpoiler() *SendLivePhotoParams {
+	p.HasSpoiler = true
+	return p
+}
+
+// WithDisableNotification adds disable notification parameter
+func (p *SendLivePhotoParams) WithDisableNotification() *SendLivePhotoParams {
+	p.DisableNotification = true
+	return p
+}
+
+// WithProtectContent adds protect content parameter
+func (p *SendLivePhotoParams) WithProtectContent() *SendLivePhotoParams {
+	p.ProtectContent = true
+	return p
+}
+
+// WithAllowPaidBroadcast adds allow paid broadcast parameter
+func (p *SendLivePhotoParams) WithAllowPaidBroadcast() *SendLivePhotoParams {
+	p.AllowPaidBroadcast = true
+	return p
+}
+
+// WithMessageEffectID adds message effect ID parameter
+func (p *SendLivePhotoParams) WithMessageEffectID(messageEffectID string) *SendLivePhotoParams {
+	p.MessageEffectID = messageEffectID
+	return p
+}
+
+// WithSuggestedPostParameters adds suggested post parameters parameter
+func (p *SendLivePhotoParams) WithSuggestedPostParameters(suggestedPostParameters *SuggestedPostParameters,
+) *SendLivePhotoParams {
+	p.SuggestedPostParameters = suggestedPostParameters
+	return p
+}
+
+// WithReplyParameters adds reply parameters parameter
+func (p *SendLivePhotoParams) WithReplyParameters(replyParameters *ReplyParameters) *SendLivePhotoParams {
+	p.ReplyParameters = replyParameters
+	return p
+}
+
+// WithReplyMarkup adds reply markup parameter
+func (p *SendLivePhotoParams) WithReplyMarkup(replyMarkup ReplyMarkup) *SendLivePhotoParams {
+	p.ReplyMarkup = replyMarkup
+	return p
+}
+
+// WithBusinessConnectionID adds business connection ID parameter
 func (p *SendVideoNoteParams) WithBusinessConnectionID(businessConnectionID string) *SendVideoNoteParams {
 	p.BusinessConnectionID = businessConnectionID
 	return p
@@ -1754,6 +1863,18 @@ func (p *SendPollParams) WithHideResultsUntilCloses() *SendPollParams {
 	return p
 }
 
+// WithMembersOnly adds members only parameter
+func (p *SendPollParams) WithMembersOnly() *SendPollParams {
+	p.MembersOnly = true
+	return p
+}
+
+// WithCountryCodes adds country codes parameter
+func (p *SendPollParams) WithCountryCodes(countryCodes ...string) *SendPollParams {
+	p.CountryCodes = countryCodes
+	return p
+}
+
 // WithCorrectOptionIDs adds correct option ids parameter
 func (p *SendPollParams) WithCorrectOptionIDs(correctOptionIDs ...int) *SendPollParams {
 	p.CorrectOptionIDs = correctOptionIDs
@@ -1775,6 +1896,12 @@ func (p *SendPollParams) WithExplanationParseMode(explanationParseMode string) *
 // WithExplanationEntities adds explanation entities parameter
 func (p *SendPollParams) WithExplanationEntities(explanationEntities ...MessageEntity) *SendPollParams {
 	p.ExplanationEntities = explanationEntities
+	return p
+}
+
+// WithExplanationMedia adds explanation media parameter
+func (p *SendPollParams) WithExplanationMedia(explanationMedia InputPollMedia) *SendPollParams {
+	p.ExplanationMedia = explanationMedia
 	return p
 }
 
@@ -1811,6 +1938,12 @@ func (p *SendPollParams) WithDescriptionParseMode(descriptionParseMode string) *
 // WithDescriptionEntities adds description entities parameter
 func (p *SendPollParams) WithDescriptionEntities(descriptionEntities ...MessageEntity) *SendPollParams {
 	p.DescriptionEntities = descriptionEntities
+	return p
+}
+
+// WithMedia adds media parameter
+func (p *SendPollParams) WithMedia(media InputPollMedia) *SendPollParams {
+	p.Media = media
 	return p
 }
 
@@ -2051,6 +2184,48 @@ func (p *SetMessageReactionParams) WithReaction(reaction ...ReactionType) *SetMe
 // WithIsBig adds is big parameter
 func (p *SetMessageReactionParams) WithIsBig() *SetMessageReactionParams {
 	p.IsBig = true
+	return p
+}
+
+// WithChatID adds chat ID parameter
+func (p *DeleteMessageReactionParams) WithChatID(chatID ChatID) *DeleteMessageReactionParams {
+	p.ChatID = chatID
+	return p
+}
+
+// WithMessageID adds message ID parameter
+func (p *DeleteMessageReactionParams) WithMessageID(messageID int) *DeleteMessageReactionParams {
+	p.MessageID = messageID
+	return p
+}
+
+// WithUserID adds user ID parameter
+func (p *DeleteMessageReactionParams) WithUserID(userID int64) *DeleteMessageReactionParams {
+	p.UserID = userID
+	return p
+}
+
+// WithActorChatID adds actor chat ID parameter
+func (p *DeleteMessageReactionParams) WithActorChatID(actorChatID int64) *DeleteMessageReactionParams {
+	p.ActorChatID = actorChatID
+	return p
+}
+
+// WithChatID adds chat ID parameter
+func (p *DeleteAllMessageReactionsParams) WithChatID(chatID ChatID) *DeleteAllMessageReactionsParams {
+	p.ChatID = chatID
+	return p
+}
+
+// WithUserID adds user ID parameter
+func (p *DeleteAllMessageReactionsParams) WithUserID(userID int64) *DeleteAllMessageReactionsParams {
+	p.UserID = userID
+	return p
+}
+
+// WithActorChatID adds actor chat ID parameter
+func (p *DeleteAllMessageReactionsParams) WithActorChatID(actorChatID int64) *DeleteAllMessageReactionsParams {
+	p.ActorChatID = actorChatID
 	return p
 }
 
@@ -2641,6 +2816,12 @@ func (p *GetChatAdministratorsParams) WithChatID(chatID ChatID) *GetChatAdminist
 	return p
 }
 
+// WithReturnBots adds return bots parameter
+func (p *GetChatAdministratorsParams) WithReturnBots() *GetChatAdministratorsParams {
+	p.ReturnBots = true
+	return p
+}
+
 // WithChatID adds chat ID parameter
 func (p *GetChatMemberCountParams) WithChatID(chatID ChatID) *GetChatMemberCountParams {
 	p.ChatID = chatID
@@ -2873,6 +3054,43 @@ func (p *GetManagedBotTokenParams) WithUserID(userID int64) *GetManagedBotTokenP
 // WithUserID adds user ID parameter
 func (p *ReplaceManagedBotTokenParams) WithUserID(userID int64) *ReplaceManagedBotTokenParams {
 	p.UserID = userID
+	return p
+}
+
+// WithUserID adds user ID parameter
+func (p *GetManagedBotAccessSettingsParams) WithUserID(userID int64) *GetManagedBotAccessSettingsParams {
+	p.UserID = userID
+	return p
+}
+
+// WithUserID adds user ID parameter
+func (p *SetManagedBotAccessSettingsParams) WithUserID(userID int64) *SetManagedBotAccessSettingsParams {
+	p.UserID = userID
+	return p
+}
+
+// WithIsAccessRestricted adds is access restricted parameter
+func (p *SetManagedBotAccessSettingsParams) WithIsAccessRestricted(isAccessRestricted bool,
+) *SetManagedBotAccessSettingsParams {
+	p.IsAccessRestricted = isAccessRestricted
+	return p
+}
+
+// WithAddedUserIDs adds added user ids parameter
+func (p *SetManagedBotAccessSettingsParams) WithAddedUserIDs(addedUserIDs ...int64) *SetManagedBotAccessSettingsParams {
+	p.AddedUserIDs = addedUserIDs
+	return p
+}
+
+// WithUserID adds user ID parameter
+func (p *GetUserPersonalChatMessagesParams) WithUserID(userID int64) *GetUserPersonalChatMessagesParams {
+	p.UserID = userID
+	return p
+}
+
+// WithLimit adds limit parameter
+func (p *GetUserPersonalChatMessagesParams) WithLimit(limit int) *GetUserPersonalChatMessagesParams {
+	p.Limit = limit
 	return p
 }
 
@@ -4450,6 +4668,18 @@ func (p *AnswerInlineQueryParams) WithNextOffset(nextOffset string) *AnswerInlin
 // WithButton adds button parameter
 func (p *AnswerInlineQueryParams) WithButton(button *InlineQueryResultsButton) *AnswerInlineQueryParams {
 	p.Button = button
+	return p
+}
+
+// WithGuestQueryID adds guest query ID parameter
+func (p *AnswerGuestQueryParams) WithGuestQueryID(guestQueryID string) *AnswerGuestQueryParams {
+	p.GuestQueryID = guestQueryID
+	return p
+}
+
+// WithResult adds result parameter
+func (p *AnswerGuestQueryParams) WithResult(result InlineQueryResult) *AnswerGuestQueryParams {
+	p.Result = result
 	return p
 }
 

--- a/methods_setters_test.go
+++ b/methods_setters_test.go
@@ -470,6 +470,49 @@ func TestSendVoiceParams_Setters(t *testing.T) {
 	}, s)
 }
 
+func TestSendLivePhotoParams_Setters(t *testing.T) {
+	s := (&SendLivePhotoParams{}).
+		WithBusinessConnectionID("BusinessConnectionID").
+		WithChatID(ChatID{ID: 1}).
+		WithMessageThreadID(2).
+		WithDirectMessagesTopicID(3).
+		WithLivePhoto(testInputFile).
+		WithPhoto(testInputFile).
+		WithCaption("Caption").
+		WithParseMode("ParseMode").
+		WithCaptionEntities([]MessageEntity{{Type: "CaptionEntities"}}...).
+		WithShowCaptionAboveMedia().
+		WithHasSpoiler().
+		WithDisableNotification().
+		WithProtectContent().
+		WithAllowPaidBroadcast().
+		WithMessageEffectID("MessageEffectID").
+		WithSuggestedPostParameters(&SuggestedPostParameters{}).
+		WithReplyParameters(&ReplyParameters{MessageID: 4}).
+		WithReplyMarkup(&ReplyKeyboardRemove{RemoveKeyboard: true})
+
+	assert.Equal(t, &SendLivePhotoParams{
+		BusinessConnectionID:    "BusinessConnectionID",
+		ChatID:                  ChatID{ID: 1},
+		MessageThreadID:         2,
+		DirectMessagesTopicID:   3,
+		LivePhoto:               testInputFile,
+		Photo:                   testInputFile,
+		Caption:                 "Caption",
+		ParseMode:               "ParseMode",
+		CaptionEntities:         []MessageEntity{{Type: "CaptionEntities"}},
+		ShowCaptionAboveMedia:   true,
+		HasSpoiler:              true,
+		DisableNotification:     true,
+		ProtectContent:          true,
+		AllowPaidBroadcast:      true,
+		MessageEffectID:         "MessageEffectID",
+		SuggestedPostParameters: &SuggestedPostParameters{},
+		ReplyParameters:         &ReplyParameters{MessageID: 4},
+		ReplyMarkup:             &ReplyKeyboardRemove{RemoveKeyboard: true},
+	}, s)
+}
+
 func TestSendVideoNoteParams_Setters(t *testing.T) {
 	s := (&SendVideoNoteParams{}).
 		WithBusinessConnectionID("BusinessConnectionID").
@@ -714,16 +757,20 @@ func TestSendPollParams_Setters(t *testing.T) {
 		WithShuffleOptions().
 		WithAllowAddingOptions().
 		WithHideResultsUntilCloses().
+		WithMembersOnly().
+		WithCountryCodes([]string{"FT"}...).
 		WithCorrectOptionIDs([]int{3}...).
 		WithExplanation("Explanation").
 		WithExplanationParseMode("ExplanationParseMode").
 		WithExplanationEntities([]MessageEntity{{Type: "ExplanationEntities"}}...).
+		WithExplanationMedia(&InputMediaPhoto{}).
 		WithOpenPeriod(4).
 		WithCloseDate(5).
 		WithIsClosed().
 		WithDescription("Description").
 		WithDescriptionParseMode("DescriptionParseMode").
 		WithDescriptionEntities([]MessageEntity{{Type: "DescriptionEntities"}}...).
+		WithMedia(&InputMediaPhoto{}).
 		WithDisableNotification().
 		WithProtectContent().
 		WithAllowPaidBroadcast().
@@ -746,16 +793,20 @@ func TestSendPollParams_Setters(t *testing.T) {
 		ShuffleOptions:         true,
 		AllowAddingOptions:     true,
 		HideResultsUntilCloses: true,
+		MembersOnly:            true,
+		CountryCodes:           []string{"FT"},
 		CorrectOptionIDs:       []int{3},
 		Explanation:            "Explanation",
 		ExplanationParseMode:   "ExplanationParseMode",
 		ExplanationEntities:    []MessageEntity{{Type: "ExplanationEntities"}},
+		ExplanationMedia:       &InputMediaPhoto{},
 		OpenPeriod:             4,
 		CloseDate:              5,
 		IsClosed:               true,
 		Description:            "Description",
 		DescriptionParseMode:   "DescriptionParseMode",
 		DescriptionEntities:    []MessageEntity{{Type: "DescriptionEntities"}},
+		Media:                  &InputMediaPhoto{},
 		DisableNotification:    true,
 		ProtectContent:         true,
 		AllowPaidBroadcast:     true,
@@ -866,6 +917,34 @@ func TestSetMessageReactionParams_Setters(t *testing.T) {
 		Reaction:  []ReactionType{&ReactionTypeEmoji{Type: ReactionEmoji}},
 		IsBig:     true,
 	}, s)
+}
+
+func TestDeleteMessageReactionParams_Setters(t *testing.T) {
+	d := (&DeleteMessageReactionParams{}).
+		WithChatID(ChatID{ID: 1}).
+		WithMessageID(2).
+		WithUserID(3).
+		WithActorChatID(4)
+
+	assert.Equal(t, &DeleteMessageReactionParams{
+		ChatID:      ChatID{ID: 1},
+		MessageID:   2,
+		UserID:      3,
+		ActorChatID: 4,
+	}, d)
+}
+
+func TestDeleteAllMessageReactionsParams_Setters(t *testing.T) {
+	d := (&DeleteAllMessageReactionsParams{}).
+		WithChatID(ChatID{ID: 1}).
+		WithUserID(2).
+		WithActorChatID(3)
+
+	assert.Equal(t, &DeleteAllMessageReactionsParams{
+		ChatID:      ChatID{ID: 1},
+		UserID:      2,
+		ActorChatID: 3,
+	}, d)
 }
 
 func TestGetUserProfilePhotosParams_Setters(t *testing.T) {
@@ -1272,10 +1351,12 @@ func TestGetChatParams_Setters(t *testing.T) {
 
 func TestGetChatAdministratorsParams_Setters(t *testing.T) {
 	g := (&GetChatAdministratorsParams{}).
-		WithChatID(ChatID{ID: 1})
+		WithChatID(ChatID{ID: 1}).
+		WithReturnBots()
 
 	assert.Equal(t, &GetChatAdministratorsParams{
-		ChatID: ChatID{ID: 1},
+		ChatID:     ChatID{ID: 1},
+		ReturnBots: true,
 	}, g)
 }
 
@@ -1502,6 +1583,39 @@ func TestReplaceManagedBotTokenParams_Setters(t *testing.T) {
 	assert.Equal(t, &ReplaceManagedBotTokenParams{
 		UserID: 1,
 	}, r)
+}
+
+func TestGetManagedBotAccessSettingsParams_Setters(t *testing.T) {
+	g := (&GetManagedBotAccessSettingsParams{}).
+		WithUserID(1)
+
+	assert.Equal(t, &GetManagedBotAccessSettingsParams{
+		UserID: 1,
+	}, g)
+}
+
+func TestSetManagedBotAccessSettingsParams_Setters(t *testing.T) {
+	s := (&SetManagedBotAccessSettingsParams{}).
+		WithUserID(1).
+		WithIsAccessRestricted(true).
+		WithAddedUserIDs([]int64{2}...)
+
+	assert.Equal(t, &SetManagedBotAccessSettingsParams{
+		UserID:             1,
+		IsAccessRestricted: true,
+		AddedUserIDs:       []int64{2},
+	}, s)
+}
+
+func TestGetUserPersonalChatMessagesParams_Setters(t *testing.T) {
+	g := (&GetUserPersonalChatMessagesParams{}).
+		WithUserID(1).
+		WithLimit(2)
+
+	assert.Equal(t, &GetUserPersonalChatMessagesParams{
+		UserID: 1,
+		Limit:  2,
+	}, g)
 }
 
 func TestSetMyCommandsParams_Setters(t *testing.T) {
@@ -2523,6 +2637,17 @@ func TestAnswerInlineQueryParams_Setters(t *testing.T) {
 		IsPersonal:    true,
 		NextOffset:    "NextOffset",
 		Button:        &InlineQueryResultsButton{},
+	}, a)
+}
+
+func TestAnswerGuestQueryParams_Setters(t *testing.T) {
+	a := (&AnswerGuestQueryParams{}).
+		WithGuestQueryID("GuestQueryID").
+		WithResult(&InlineQueryResultArticle{Type: "Result"})
+
+	assert.Equal(t, &AnswerGuestQueryParams{
+		GuestQueryID: "GuestQueryID",
+		Result:       &InlineQueryResultArticle{Type: "Result"},
 	}, a)
 }
 

--- a/methods_test.go
+++ b/methods_test.go
@@ -559,6 +559,36 @@ func TestBot_SendVoice(t *testing.T) {
 	})
 }
 
+func TestBot_SendLivePhoto(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := newMockedBot(ctrl)
+
+	t.Run("success", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(data, nil)
+
+		resp := telegoResponse(t, expectedMessage)
+		m.MockAPICaller.EXPECT().
+			Call(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(resp, nil)
+
+		message, err := m.Bot.SendLivePhoto(t.Context(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedMessage, message)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(nil, errTest)
+
+		message, err := m.Bot.SendLivePhoto(t.Context(), nil)
+		require.Error(t, err)
+		assert.Nil(t, message)
+	})
+}
+
 func TestBot_SendVideoNote(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	m := newMockedBot(ctrl)
@@ -910,6 +940,60 @@ func TestBot_SetMessageReaction(t *testing.T) {
 			Return(nil, errTest)
 
 		err := m.Bot.SetMessageReaction(t.Context(), nil)
+		require.Error(t, err)
+	})
+}
+
+func TestBot_DeleteMessageReaction(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := newMockedBot(ctrl)
+
+	t.Run("success", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(data, nil)
+
+		m.MockAPICaller.EXPECT().
+			Call(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(emptyResp, nil)
+
+		err := m.Bot.DeleteMessageReaction(t.Context(), nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(nil, errTest)
+
+		err := m.Bot.DeleteMessageReaction(t.Context(), nil)
+		require.Error(t, err)
+	})
+}
+
+func TestBot_DeleteAllMessageReactions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := newMockedBot(ctrl)
+
+	t.Run("success", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(data, nil)
+
+		m.MockAPICaller.EXPECT().
+			Call(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(emptyResp, nil)
+
+		err := m.Bot.DeleteAllMessageReactions(t.Context(), nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(nil, errTest)
+
+		err := m.Bot.DeleteAllMessageReactions(t.Context(), nil)
 		require.Error(t, err)
 	})
 }
@@ -2443,6 +2527,95 @@ func TestBot_ReplaceManagedBotToken(t *testing.T) {
 		token, err := m.Bot.ReplaceManagedBotToken(t.Context(), nil)
 		require.Error(t, err)
 		assert.Nil(t, token)
+	})
+}
+
+func TestBot_GetManagedBotAccessSettings(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := newMockedBot(ctrl)
+
+	t.Run("success", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(data, nil)
+
+		expected := &BotAccessSettings{IsAccessRestricted: true}
+		resp := telegoResponse(t, expected)
+		m.MockAPICaller.EXPECT().
+			Call(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(resp, nil)
+
+		settings, err := m.Bot.GetManagedBotAccessSettings(t.Context(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, expected, settings)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(nil, errTest)
+
+		settings, err := m.Bot.GetManagedBotAccessSettings(t.Context(), nil)
+		require.Error(t, err)
+		assert.Nil(t, settings)
+	})
+}
+
+func TestBot_SetManagedBotAccessSettings(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := newMockedBot(ctrl)
+
+	t.Run("success", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(data, nil)
+
+		m.MockAPICaller.EXPECT().
+			Call(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(emptyResp, nil)
+
+		err := m.Bot.SetManagedBotAccessSettings(t.Context(), nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(nil, errTest)
+
+		err := m.Bot.SetManagedBotAccessSettings(t.Context(), nil)
+		require.Error(t, err)
+	})
+}
+
+func TestBot_GetUserPersonalChatMessages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := newMockedBot(ctrl)
+
+	t.Run("success", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(data, nil)
+
+		expected := []Message{{MessageID: 1}}
+		resp := telegoResponse(t, expected)
+		m.MockAPICaller.EXPECT().
+			Call(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(resp, nil)
+
+		messages, err := m.Bot.GetUserPersonalChatMessages(t.Context(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, expected, messages)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(nil, errTest)
+
+		messages, err := m.Bot.GetUserPersonalChatMessages(t.Context(), nil)
+		require.Error(t, err)
+		assert.Nil(t, messages)
 	})
 }
 
@@ -4585,6 +4758,37 @@ func TestBot_AnswerInlineQuery(t *testing.T) {
 	})
 }
 
+func TestBot_AnswerGuestQuery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := newMockedBot(ctrl)
+
+	t.Run("success", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(data, nil)
+
+		expected := &SentGuestMessage{InlineMessageID: "1"}
+		resp := telegoResponse(t, expected)
+		m.MockAPICaller.EXPECT().
+			Call(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(resp, nil)
+
+		sent, err := m.Bot.AnswerGuestQuery(t.Context(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, expected, sent)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		m.MockRequestConstructor.EXPECT().
+			JSONRequest(gomock.Any()).
+			Return(nil, errTest)
+
+		sent, err := m.Bot.AnswerGuestQuery(t.Context(), nil)
+		require.Error(t, err)
+		assert.Nil(t, sent)
+	})
+}
+
 func TestBot_SendInvoice(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	m := newMockedBot(ctrl)
@@ -5048,6 +5252,31 @@ func TestSendMediaGroupParams_fileParameters(t *testing.T) {
 	assert.Equal(t, map[string]ta.NamedReader{
 		"test": testNamedReader{},
 	}, p.fileParameters())
+}
+
+func TestSendPollParams_fileParameters(t *testing.T) {
+	t.Run("nil media", func(t *testing.T) {
+		p := &SendPollParams{}
+		assert.Equal(t, map[string]ta.NamedReader{}, p.fileParameters())
+	})
+
+	t.Run("aggregates media + explanation_media + options", func(t *testing.T) {
+		p := &SendPollParams{
+			Media: &InputMediaPhoto{Media: testInputFile},
+			ExplanationMedia: &InputMediaDocument{
+				Media:     testInputFile,
+				Thumbnail: &InputFile{File: nil},
+			},
+			Options: []InputPollOption{
+				{Media: &InputMediaSticker{Media: testInputFile}},
+				{},
+			},
+		}
+
+		assert.Equal(t, map[string]ta.NamedReader{
+			"test": testNamedReader{},
+		}, p.fileParameters())
+	})
 }
 
 func TestSetChatPhotoParams_fileParameters(t *testing.T) {

--- a/telegohandler/handlers.go
+++ b/telegohandler/handlers.go
@@ -145,6 +145,22 @@ func (h *BotHandler) HandleDeletedBusinessMessages(handler DeletedBusinessMessag
 	h.baseGroup.HandleDeletedBusinessMessages(handler, predicates...)
 }
 
+// HandleGuestMessage same as [BotHandler.Handle], but assumes that the update contains a guest message
+func (h *HandlerGroup) HandleGuestMessage(handler MessageHandler, predicates ...Predicate) {
+	if handler == nil {
+		panic("Telego: nil guest message handlers not allowed")
+	}
+
+	h.Handle(func(ctx *Context, update telego.Update) error {
+		return handler(ctx, *update.GuestMessage)
+	}, append([]Predicate{AnyGuestMessage()}, predicates...)...)
+}
+
+// HandleGuestMessage same as [BotHandler.Handle], but assumes that the update contains a guest message
+func (h *BotHandler) HandleGuestMessage(handler MessageHandler, predicates ...Predicate) {
+	h.baseGroup.HandleGuestMessage(handler, predicates...)
+}
+
 // MessageReactionHandler handles message reaction that came from bot
 type MessageReactionHandler func(ctx *Context, reaction telego.MessageReactionUpdated) error
 

--- a/telegohandler/handlers_test.go
+++ b/telegohandler/handlers_test.go
@@ -194,6 +194,24 @@ func TestBotHandler_HandleDeletedBusinessMessages(t *testing.T) {
 	testHandler(t, bh, wg)
 }
 
+func TestBotHandler_HandleGuestMessage(t *testing.T) {
+	bh := newTestBotHandler(t)
+
+	require.Panics(t, func() { bh.HandleGuestMessage(nil) })
+
+	wg := &sync.WaitGroup{}
+	handler := MessageHandler(func(_ *Context, _ telego.Message) error { wg.Done(); return nil })
+
+	bh.HandleGuestMessage(handler)
+	testHandlerSetup(t, bh)
+
+	updates := make(chan telego.Update, 1)
+	updates <- telego.Update{GuestMessage: &telego.Message{}}
+
+	bh.updates = updates
+	testHandler(t, bh, wg)
+}
+
 func TestBotHandler_HandleMessageReaction(t *testing.T) {
 	bh := newTestBotHandler(t)
 

--- a/telegohandler/predicates.go
+++ b/telegohandler/predicates.go
@@ -519,6 +519,13 @@ func AnyDeletedBusinessMessages() Predicate {
 	}
 }
 
+// AnyGuestMessage is true if the guest message isn't nil
+func AnyGuestMessage() Predicate {
+	return func(_ context.Context, update telego.Update) bool {
+		return baseAnyMessage(update.GuestMessage)
+	}
+}
+
 // AnyMessageReaction is true if message reaction isn't nil
 func AnyMessageReaction() Predicate {
 	return func(_ context.Context, update telego.Update) bool {

--- a/telegohandler/predicates_test.go
+++ b/telegohandler/predicates_test.go
@@ -727,6 +727,18 @@ func TestPredicates(t *testing.T) {
 			matches:   false,
 		},
 		{
+			name:      "any_guest_message_matches",
+			predicate: AnyGuestMessage(),
+			update:    telego.Update{GuestMessage: &telego.Message{Chat: telego.Chat{ID: 1}}},
+			matches:   true,
+		},
+		{
+			name:      "any_guest_message_not_matches",
+			predicate: AnyGuestMessage(),
+			update:    telego.Update{},
+			matches:   false,
+		},
+		{
 			name:      "any_message_reaction_matches",
 			predicate: AnyMessageReaction(),
 			update:    telego.Update{MessageReaction: &telego.MessageReactionUpdated{}},

--- a/types.go
+++ b/types.go
@@ -49,6 +49,10 @@ type Update struct {
 	// DeletedBusinessMessages - Optional. Messages were deleted from a connected business account
 	DeletedBusinessMessages *BusinessMessagesDeleted `json:"deleted_business_messages,omitempty"`
 
+	// GuestMessage - Optional. New guest message. The bot can use the field Message.guest_query_id and the
+	// method answerGuestQuery (https://core.telegram.org/bots/api#answerguestquery) to send a message in response.
+	GuestMessage *Message `json:"guest_message,omitempty"`
+
 	// MessageReaction - Optional. A reaction to a message was changed by a user. The bot must be an
 	// administrator in the chat and must explicitly specify "message_reaction" in the list of allowed_updates to
 	// receive these updates. The update isn't received for reactions set by bots.
@@ -242,6 +246,10 @@ type User struct {
 	// (https://core.telegram.org/bots/features#privacy-mode) is disabled for the bot. Returned only in getMe
 	// (https://core.telegram.org/bots/api#getme).
 	CanReadAllGroupMessages bool `json:"can_read_all_group_messages,omitempty"`
+
+	// SupportsGuestQueries - Optional. True, if the bot supports guest queries from chats it is not a member of.
+	// Returned only in getMe (https://core.telegram.org/bots/api#getme).
+	SupportsGuestQueries bool `json:"supports_guest_queries,omitempty"`
 
 	// SupportsInlineQueries - Optional. True, if the bot supports inline queries. Returned only in getMe
 	// (https://core.telegram.org/bots/api#getme).
@@ -586,6 +594,12 @@ type Message struct {
 	// Date - Date the message was sent in Unix time. It is always a positive number, representing a valid date.
 	Date int64 `json:"date"`
 
+	// GuestQueryID - Optional. The unique identifier for the guest query. Use this identifier with the method
+	// answerGuestQuery (https://core.telegram.org/bots/api#answerguestquery) to send a response message. If
+	// non-empty, the message belongs to the chat where the guest bot was summoned, which may not coincide with
+	// other existing bot chats sharing the same identifier.
+	GuestQueryID string `json:"guest_query_id,omitempty"`
+
 	// BusinessConnectionID - Optional. Unique identifier of the business connection from which the message was
 	// received. If non-empty, the message belongs to a chat of the corresponding business account that is
 	// independent from any potential bot chat which might share the same identifier.
@@ -629,6 +643,14 @@ type Message struct {
 
 	// ViaBot - Optional. Bot through which the message was sent
 	ViaBot *User `json:"via_bot,omitempty"`
+
+	// GuestBotCallerUser - Optional. For a message sent by a guest bot, this is the user whose original message
+	// triggered the bot's response.
+	GuestBotCallerUser *User `json:"guest_bot_caller_user,omitempty"`
+
+	// GuestBotCallerChat - Optional. For a message sent by a guest bot, this is the chat whose original message
+	// triggered the bot's response.
+	GuestBotCallerChat *Chat `json:"guest_bot_caller_chat,omitempty"`
 
 	// EditDate - Optional. Date the message was last edited in Unix time
 	EditDate int64 `json:"edit_date,omitempty"`
@@ -684,6 +706,10 @@ type Message struct {
 
 	// Document - Optional. Message is a general file, information about the file
 	Document *Document `json:"document,omitempty"`
+
+	// LivePhoto - Optional. Message is a live photo, information about the live photo. For backward
+	// compatibility, when this field is set, the photo field will also be set.
+	LivePhoto *LivePhoto `json:"live_photo,omitempty"`
 
 	// PaidMedia - Optional. Message contains paid media; information about the paid media
 	PaidMedia *PaidMediaInfo `json:"paid_media,omitempty"`
@@ -1203,6 +1229,9 @@ type ExternalReplyInfo struct {
 	// Document - Optional. Message is a general file, information about the file
 	Document *Document `json:"document,omitempty"`
 
+	// LivePhoto - Optional. Message is a live photo, information about the live photo.
+	LivePhoto *LivePhoto `json:"live_photo,omitempty"`
+
 	// PaidMedia - Optional. Message contains paid media; information about the paid media
 	PaidMedia *PaidMediaInfo `json:"paid_media,omitempty"`
 
@@ -1701,6 +1730,36 @@ type Voice struct {
 	FileSize int64 `json:"file_size,omitempty"`
 }
 
+// LivePhoto - This object represents a live photo.
+type LivePhoto struct {
+	// Photo - Optional. Available sizes of the corresponding static photo
+	Photo []PhotoSize `json:"photo,omitempty"`
+
+	// FileID - Identifier for the video file which can be used to download or reuse the file
+	FileID string `json:"file_id"`
+
+	// FileUniqueID - Unique identifier for the video file which is supposed to be the same over time and for
+	// different bots. Can't be used to download or reuse the file.
+	FileUniqueID string `json:"file_unique_id"`
+
+	// Width - Video width as defined by the sender
+	Width int `json:"width"`
+
+	// Height - Video height as defined by the sender
+	Height int `json:"height"`
+
+	// Duration - Duration of the video in seconds as defined by the sender
+	Duration int `json:"duration"`
+
+	// MimeType - Optional. MIME type of the file as defined by the sender
+	MimeType string `json:"mime_type,omitempty"`
+
+	// FileSize - Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may
+	// have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit
+	// integer or double-precision float type are safe for storing this value.
+	FileSize int64 `json:"file_size,omitempty"`
+}
+
 // PaidMediaInfo - Describes the paid media added to a message.
 type PaidMediaInfo struct {
 	// StarCount - The number of Telegram Stars that must be paid to buy access to the media
@@ -1735,6 +1794,8 @@ func (m *PaidMediaInfo) UnmarshalJSON(data []byte) error {
 				um.PaidMedia[i] = &PaidMediaPhoto{}
 			case PaidMediaTypeVideo:
 				um.PaidMedia[i] = &PaidMediaVideo{}
+			case PaidMediaTypeLivePhoto:
+				um.PaidMedia[i] = &PaidMediaLivePhoto{}
 			case paidMediaTypeOther:
 				um.PaidMedia[i] = &paidMediaOther{}
 			default:
@@ -1755,6 +1816,7 @@ func (m *PaidMediaInfo) UnmarshalJSON(data []byte) error {
 // PaidMediaPreview (https://core.telegram.org/bots/api#paidmediapreview)
 // PaidMediaPhoto (https://core.telegram.org/bots/api#paidmediaphoto)
 // PaidMediaVideo (https://core.telegram.org/bots/api#paidmediavideo)
+// PaidMediaLivePhoto (https://core.telegram.org/bots/api#paidmedialivephoto)
 //
 // WARNING: Telegram introduced undocumented type "other", it will be correctly parsed by Telego, but will not be
 // exposed to users directly as it's not documented anywhere, but still used by Telegram
@@ -1767,10 +1829,11 @@ type PaidMedia interface {
 
 // Paid media types
 const (
-	PaidMediaTypePreview = "preview"
-	PaidMediaTypePhoto   = "photo"
-	PaidMediaTypeVideo   = "video"
-	paidMediaTypeOther   = "other"
+	PaidMediaTypePreview   = "preview"
+	PaidMediaTypePhoto     = "photo"
+	PaidMediaTypeVideo     = "video"
+	PaidMediaTypeLivePhoto = "live_photo"
+	paidMediaTypeOther     = "other"
 )
 
 // PaidMediaPreview - The paid media isn't available before the payment.
@@ -1826,6 +1889,22 @@ func (m *PaidMediaVideo) MediaType() string {
 }
 
 func (m *PaidMediaVideo) iPaidMedia() {}
+
+// PaidMediaLivePhoto - The paid media is a live photo (https://core.telegram.org/bots/api#livephoto).
+type PaidMediaLivePhoto struct {
+	// Type - Type of the paid media, always “live_photo”
+	Type string `json:"type"`
+
+	// LivePhoto - The photo
+	LivePhoto LivePhoto `json:"live_photo"`
+}
+
+// MediaType returns PaidMedia type
+func (m *PaidMediaLivePhoto) MediaType() string {
+	return PaidMediaTypeLivePhoto
+}
+
+func (m *PaidMediaLivePhoto) iPaidMedia() {}
 
 // paidMediaOther - The paid media is a other.
 //
@@ -1896,6 +1975,9 @@ type PollOption struct {
 	// entities are allowed in poll option texts
 	TextEntities []MessageEntity `json:"text_entities,omitempty"`
 
+	// Media - Optional. Media added to the poll option
+	Media *PollMedia `json:"media,omitempty"`
+
 	// VoterCount - Number of users who voted for this option; may be 0 if unknown
 	VoterCount int `json:"voter_count"`
 
@@ -1925,6 +2007,9 @@ type InputPollOption struct {
 	// TextEntities - Optional. A JSON-serialized list of special entities that appear in the poll option text.
 	// It can be specified instead of text_parse_mode
 	TextEntities []MessageEntity `json:"text_entities,omitempty"`
+
+	// Media - Optional. Media added to the poll option
+	Media InputPollOptionMedia `json:"media,omitempty"`
 }
 
 // PollAnswer - This object represents an answer of a user in a non-anonymous poll.
@@ -1979,6 +2064,16 @@ type Poll struct {
 	// AllowsRevoting - True, if the poll allows to change the chosen answer options
 	AllowsRevoting bool `json:"allows_revoting"`
 
+	// MembersOnly - True if voting is limited to users who have been members of the chat where the poll was
+	// originally sent for more than 24 hours
+	MembersOnly bool `json:"members_only"`
+
+	// CountryCodes - Optional. A list of two-letter ISO 3166-1 alpha-2
+	// (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes indicating the countries from which users
+	// can vote in the poll. The country code "FT" is used for users with anonymous numbers. If omitted, then users
+	// from any country can participate in the poll.
+	CountryCodes []string `json:"country_codes,omitempty"`
+
 	// CorrectOptionIDs - Optional. Array of 0-based identifiers of the correct answer options. Available only
 	// for polls in quiz mode which are closed or were sent (not forwarded) by the bot or to the private chat with
 	// the bot.
@@ -1991,6 +2086,9 @@ type Poll struct {
 	// ExplanationEntities - Optional. Special entities like usernames, URLs, bot commands, etc. that appear in
 	// the explanation
 	ExplanationEntities []MessageEntity `json:"explanation_entities,omitempty"`
+
+	// ExplanationMedia - Optional. Media added to the quiz explanation
+	ExplanationMedia *PollMedia `json:"explanation_media,omitempty"`
 
 	// OpenPeriod - Optional. Amount of time in seconds the poll will be active after creation
 	OpenPeriod int `json:"open_period,omitempty"`
@@ -2005,6 +2103,10 @@ type Poll struct {
 	// DescriptionEntities - Optional. Special entities like usernames, URLs, bot commands, etc. that appear in
 	// the description
 	DescriptionEntities []MessageEntity `json:"description_entities,omitempty"`
+
+	// Media - Optional. Media added to the poll description; for polls inside the Message
+	// (https://core.telegram.org/bots/api#message) object only
+	Media *PollMedia `json:"media,omitempty"`
 }
 
 // Poll types
@@ -2012,6 +2114,39 @@ const (
 	PollTypeRegular = "regular"
 	PollTypeQuiz    = "quiz"
 )
+
+// PollMedia - This object represents a media in a poll. At most one of the optional fields can be present
+// in any given object.
+type PollMedia struct {
+	// Animation - Optional. Media is an animation, information about the animation
+	Animation *Animation `json:"animation,omitempty"`
+
+	// Audio - Optional. Media is an audio file, information about the file; currently, can't be received in a
+	// poll option
+	Audio *Audio `json:"audio,omitempty"`
+
+	// Document - Optional. Media is a general file, information about the file; currently, can't be received in
+	// a poll option
+	Document *Document `json:"document,omitempty"`
+
+	// LivePhoto - Optional. Media is a live photo, information about the live photo
+	LivePhoto *LivePhoto `json:"live_photo,omitempty"`
+
+	// Location - Optional. Media is a shared location, information about the location
+	Location *Location `json:"location,omitempty"`
+
+	// Photo - Optional. Media is a photo, available sizes of the photo
+	Photo []PhotoSize `json:"photo,omitempty"`
+
+	// Sticker - Optional. Media is a sticker, information about the sticker; currently, for poll options only
+	Sticker *Sticker `json:"sticker,omitempty"`
+
+	// Venue - Optional. Media is a venue, information about the venue
+	Venue *Venue `json:"venue,omitempty"`
+
+	// Video - Optional. Media is a video, information about the video
+	Video *Video `json:"video,omitempty"`
+}
 
 // ChecklistTask - Describes a task in a checklist.
 type ChecklistTask struct {
@@ -2220,6 +2355,22 @@ type ManagedBotUpdated struct {
 	// Bot - Information about the bot. Token of the bot can be fetched using the method getManagedBotToken
 	// (https://core.telegram.org/bots/api#getmanagedbottoken).
 	Bot User `json:"bot"`
+}
+
+// BotAccessSettings - This object describes the access settings of a bot.
+type BotAccessSettings struct {
+	// IsAccessRestricted - True, if only selected users can access the bot. The bot's owner can always access
+	// it.
+	IsAccessRestricted bool `json:"is_access_restricted"`
+
+	// AddedUsers - Optional. The list of other users who have access to the bot if the access is restricted
+	AddedUsers []User `json:"added_users,omitempty"`
+}
+
+// SentGuestMessage - Describes an inline message sent by a guest bot.
+type SentGuestMessage struct {
+	// InlineMessageID - Identifier of the sent inline message
+	InlineMessageID string `json:"inline_message_id"`
 }
 
 // PollOptionAdded - Describes a service message about an option added to a poll.
@@ -3966,6 +4117,9 @@ type ChatMemberRestricted struct {
 	// CanAddWebPagePreviews - True, if the user is allowed to add web page previews to their messages
 	CanAddWebPagePreviews bool `json:"can_add_web_page_previews"`
 
+	// CanReactToMessages - True, if the user is allowed to react to messages
+	CanReactToMessages bool `json:"can_react_to_messages"`
+
 	// CanEditTag - True, if the user is allowed to edit their own tag
 	CanEditTag bool `json:"can_edit_tag"`
 
@@ -4119,6 +4273,10 @@ type ChatPermissions struct {
 
 	// CanAddWebPagePreviews - Optional. True, if the user is allowed to add web page previews to their messages
 	CanAddWebPagePreviews *bool `json:"can_add_web_page_previews,omitempty"`
+
+	// CanReactToMessages - Optional. True, if the user is allowed to react to messages. If omitted, defaults to
+	// the value of can_send_messages
+	CanReactToMessages *bool `json:"can_react_to_messages,omitempty"`
 
 	// CanEditTag - Optional. True, if the user is allowed to edit their own tag
 	CanEditTag *bool `json:"can_edit_tag,omitempty"`
@@ -5760,6 +5918,7 @@ type fileCompatible interface {
 // InputMediaAnimation (https://core.telegram.org/bots/api#inputmediaanimation)
 // InputMediaDocument (https://core.telegram.org/bots/api#inputmediadocument)
 // InputMediaAudio (https://core.telegram.org/bots/api#inputmediaaudio)
+// InputMediaLivePhoto (https://core.telegram.org/bots/api#inputmedialivephoto)
 // InputMediaPhoto (https://core.telegram.org/bots/api#inputmediaphoto)
 // InputMediaVideo (https://core.telegram.org/bots/api#inputmediavideo)
 type InputMedia interface {
@@ -5770,6 +5929,41 @@ type InputMedia interface {
 	fileCompatible
 }
 
+// InputPollMedia - This object represents the content of a poll description or a quiz explanation to be
+// sent. It should be one of
+// InputMediaAnimation (https://core.telegram.org/bots/api#inputmediaanimation)
+// InputMediaAudio (https://core.telegram.org/bots/api#inputmediaaudio)
+// InputMediaDocument (https://core.telegram.org/bots/api#inputmediadocument)
+// InputMediaLivePhoto (https://core.telegram.org/bots/api#inputmedialivephoto)
+// InputMediaLocation (https://core.telegram.org/bots/api#inputmedialocation)
+// InputMediaPhoto (https://core.telegram.org/bots/api#inputmediaphoto)
+// InputMediaVenue (https://core.telegram.org/bots/api#inputmediavenue)
+// InputMediaVideo (https://core.telegram.org/bots/api#inputmediavideo)
+type InputPollMedia interface {
+	// MediaType return InputPollMedia type
+	MediaType() string
+	// Disallow external implementations
+	iInputPollMedia()
+	fileCompatible
+}
+
+// InputPollOptionMedia - This object represents the content of a poll option to be sent. It should be one
+// of
+// InputMediaAnimation (https://core.telegram.org/bots/api#inputmediaanimation)
+// InputMediaLivePhoto (https://core.telegram.org/bots/api#inputmedialivephoto)
+// InputMediaLocation (https://core.telegram.org/bots/api#inputmedialocation)
+// InputMediaPhoto (https://core.telegram.org/bots/api#inputmediaphoto)
+// InputMediaSticker (https://core.telegram.org/bots/api#inputmediasticker)
+// InputMediaVenue (https://core.telegram.org/bots/api#inputmediavenue)
+// InputMediaVideo (https://core.telegram.org/bots/api#inputmediavideo)
+type InputPollOptionMedia interface {
+	// MediaType return InputPollOptionMedia type
+	MediaType() string
+	// Disallow external implementations
+	iInputPollOptionMedia()
+	fileCompatible
+}
+
 // InputMedia types
 const (
 	MediaTypePhoto     = "photo"
@@ -5777,6 +5971,10 @@ const (
 	MediaTypeAnimation = "animation"
 	MediaTypeAudio     = "audio"
 	MediaTypeDocument  = "document"
+	MediaTypeLivePhoto = "live_photo"
+	MediaTypeLocation  = "location"
+	MediaTypeSticker   = "sticker"
+	MediaTypeVenue     = "venue"
 )
 
 // InputMediaPhoto - Represents a photo to be sent.
@@ -5814,6 +6012,10 @@ func (i *InputMediaPhoto) MediaType() string {
 }
 
 func (i *InputMediaPhoto) iInputMedia() {}
+
+func (i *InputMediaPhoto) iInputPollMedia() {}
+
+func (i *InputMediaPhoto) iInputPollOptionMedia() {}
 
 func (i *InputMediaPhoto) fileParameters() map[string]telegoapi.NamedReader {
 	i.Media.needAttach = true
@@ -5887,6 +6089,10 @@ func (i *InputMediaVideo) MediaType() string {
 
 func (i *InputMediaVideo) iInputMedia() {}
 
+func (i *InputMediaVideo) iInputPollMedia() {}
+
+func (i *InputMediaVideo) iInputPollOptionMedia() {}
+
 func (i *InputMediaVideo) fileParameters() map[string]telegoapi.NamedReader {
 	fp := make(map[string]telegoapi.NamedReader)
 
@@ -5958,6 +6164,10 @@ func (i *InputMediaAnimation) MediaType() string {
 
 func (i *InputMediaAnimation) iInputMedia() {}
 
+func (i *InputMediaAnimation) iInputPollMedia() {}
+
+func (i *InputMediaAnimation) iInputPollOptionMedia() {}
+
 func (i *InputMediaAnimation) fileParameters() map[string]telegoapi.NamedReader {
 	fp := make(map[string]telegoapi.NamedReader)
 
@@ -6018,6 +6228,8 @@ func (i *InputMediaAudio) MediaType() string {
 
 func (i *InputMediaAudio) iInputMedia() {}
 
+func (i *InputMediaAudio) iInputPollMedia() {}
+
 func (i *InputMediaAudio) fileParameters() map[string]telegoapi.NamedReader {
 	fp := make(map[string]telegoapi.NamedReader)
 
@@ -6073,6 +6285,8 @@ func (i *InputMediaDocument) MediaType() string {
 
 func (i *InputMediaDocument) iInputMedia() {}
 
+func (i *InputMediaDocument) iInputPollMedia() {}
+
 func (i *InputMediaDocument) fileParameters() map[string]telegoapi.NamedReader {
 	fp := make(map[string]telegoapi.NamedReader)
 
@@ -6084,6 +6298,166 @@ func (i *InputMediaDocument) fileParameters() map[string]telegoapi.NamedReader {
 	}
 
 	return fp
+}
+
+// InputMediaLivePhoto - Represents a live photo to be sent.
+type InputMediaLivePhoto struct {
+	// Type - Type of the result, must be live_photo
+	Type string `json:"type"`
+
+	// Media - Video of the live photo to send. Pass a file_id to send a file that exists on the Telegram servers
+	// (recommended) or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under
+	// <file_attach_name> name. More information on Sending Files » (https://core.telegram.org/bots/api#sending-files).
+	// Sending live photos by a URL is currently unsupported.
+	Media InputFile `json:"media"`
+
+	// Photo - The static photo to send. Pass a file_id to send a file that exists on the Telegram servers
+	// (recommended) or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under
+	// <file_attach_name> name. More information on Sending Files » (https://core.telegram.org/bots/api#sending-files).
+	// Sending live photos by a URL is currently unsupported.
+	Photo InputFile `json:"photo"`
+
+	// Caption - Optional. Caption of the live photo to be sent, 0-1024 characters after entities parsing
+	Caption string `json:"caption,omitempty"`
+
+	// ParseMode - Optional. Mode for parsing entities in the live photo caption. See formatting options
+	// (https://core.telegram.org/bots/api#formatting-options) for more details.
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// CaptionEntities - Optional. List of special entities that appear in the caption, which can be specified
+	// instead of parse_mode
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+
+	// ShowCaptionAboveMedia - Optional. Pass True, if the caption must be shown above the message media
+	ShowCaptionAboveMedia bool `json:"show_caption_above_media,omitempty"`
+
+	// HasSpoiler - Optional. Pass True if the live photo needs to be covered with a spoiler animation
+	HasSpoiler bool `json:"has_spoiler,omitempty"`
+}
+
+// MediaType return InputMedia type
+func (i *InputMediaLivePhoto) MediaType() string {
+	return MediaTypeLivePhoto
+}
+
+func (i *InputMediaLivePhoto) iInputMedia() {}
+
+func (i *InputMediaLivePhoto) iInputPollMedia() {}
+
+func (i *InputMediaLivePhoto) iInputPollOptionMedia() {}
+
+func (i *InputMediaLivePhoto) fileParameters() map[string]telegoapi.NamedReader {
+	fp := make(map[string]telegoapi.NamedReader)
+
+	i.Media.needAttach = true
+	fp["media"] = i.Media.File
+	i.Photo.needAttach = true
+	fp["photo"] = i.Photo.File
+
+	return fp
+}
+
+// InputMediaLocation - Represents a location to be sent.
+type InputMediaLocation struct {
+	// Type - Type of the result, must be location
+	Type string `json:"type"`
+
+	// Latitude - Latitude of the location
+	Latitude float64 `json:"latitude"`
+
+	// Longitude - Longitude of the location
+	Longitude float64 `json:"longitude"`
+
+	// HorizontalAccuracy - Optional. The radius of uncertainty for the location, measured in meters; 0-1500
+	HorizontalAccuracy float64 `json:"horizontal_accuracy,omitempty"`
+}
+
+// MediaType return InputMedia type
+func (i *InputMediaLocation) MediaType() string {
+	return MediaTypeLocation
+}
+
+func (i *InputMediaLocation) iInputPollMedia() {}
+
+func (i *InputMediaLocation) iInputPollOptionMedia() {}
+
+func (i *InputMediaLocation) fileParameters() map[string]telegoapi.NamedReader {
+	return nil
+}
+
+// InputMediaSticker - Represents a sticker file to be sent.
+type InputMediaSticker struct {
+	// Type - Type of the result, must be sticker
+	Type string `json:"type"`
+
+	// Media - File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended),
+	// pass an HTTP URL for Telegram to get a .WEBP sticker from the Internet, or pass
+	// “attach://<file_attach_name>” to upload a new .WEBP, .TGS, or .WEBM sticker using multipart/form-data
+	// under <file_attach_name> name. More information on Sending Files »
+	// (https://core.telegram.org/bots/api#sending-files)
+	Media InputFile `json:"media"`
+
+	// Emoji - Optional. Emoji associated with the sticker; only for just uploaded stickers
+	Emoji string `json:"emoji,omitempty"`
+}
+
+// MediaType return InputMedia type
+func (i *InputMediaSticker) MediaType() string {
+	return MediaTypeSticker
+}
+
+func (i *InputMediaSticker) iInputPollOptionMedia() {}
+
+func (i *InputMediaSticker) fileParameters() map[string]telegoapi.NamedReader {
+	i.Media.needAttach = true
+	return map[string]telegoapi.NamedReader{
+		"media": i.Media.File,
+	}
+}
+
+// InputMediaVenue - Represents a venue to be sent.
+type InputMediaVenue struct {
+	// Type - Type of the result, must be venue
+	Type string `json:"type"`
+
+	// Latitude - Latitude of the location
+	Latitude float64 `json:"latitude"`
+
+	// Longitude - Longitude of the location
+	Longitude float64 `json:"longitude"`
+
+	// Title - Name of the venue
+	Title string `json:"title"`
+
+	// Address - Address of the venue
+	Address string `json:"address"`
+
+	// FoursquareID - Optional. Foursquare identifier of the venue
+	FoursquareID string `json:"foursquare_id,omitempty"`
+
+	// FoursquareType - Optional. Foursquare type of the venue, if known. (For example, “arts_entertainment/default”,
+	// “arts_entertainment/aquarium” or “food/icecream”.)
+	FoursquareType string `json:"foursquare_type,omitempty"`
+
+	// GooglePlaceID - Optional. Google Places identifier of the venue
+	GooglePlaceID string `json:"google_place_id,omitempty"`
+
+	// GooglePlaceType - Optional. Google Places type of the venue. (See supported types
+	// (https://developers.google.com/places/web-service/supported_types).)
+	GooglePlaceType string `json:"google_place_type,omitempty"`
+}
+
+// MediaType return InputMedia type
+func (i *InputMediaVenue) MediaType() string {
+	return MediaTypeVenue
+}
+
+func (i *InputMediaVenue) iInputPollMedia() {}
+
+func (i *InputMediaVenue) iInputPollOptionMedia() {}
+
+func (i *InputMediaVenue) fileParameters() map[string]telegoapi.NamedReader {
+	return nil
 }
 
 // InputFile - This object represents the contents of a file to be uploaded. Must be posted using
@@ -6143,6 +6517,7 @@ func (i InputFile) MarshalJSON() ([]byte, error) {
 // InputPaidMedia - This object describes the paid media to be sent. Currently, it can be one of
 // InputPaidMediaPhoto (https://core.telegram.org/bots/api#inputpaidmediaphoto)
 // InputPaidMediaVideo (https://core.telegram.org/bots/api#inputpaidmediavideo)
+// InputPaidMediaLivePhoto (https://core.telegram.org/bots/api#inputpaidmedialivephoto)
 type InputPaidMedia interface {
 	// MediaType returns InputPaidMedia type
 	MediaType() string
@@ -6250,6 +6625,47 @@ func (i *InputPaidMediaVideo) fileParameters() map[string]telegoapi.NamedReader 
 		i.Cover.needAttach = true
 		fp["cover"] = i.Cover.File
 	}
+
+	return fp
+}
+
+// InputPaidMediaLivePhoto - The paid media to send is a live photo.
+type InputPaidMediaLivePhoto struct {
+	// Type - Type of the media, must be live_photo
+	Type string `json:"type"`
+
+	// Media - Video of the live photo to send. Pass a file_id to send a file that exists on the Telegram servers
+	// (recommended) or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under
+	// <file_attach_name> name. More information on Sending Files » (https://core.telegram.org/bots/api#sending-files).
+	// Sending live photos by a URL is currently unsupported.
+	Media InputFile `json:"media"`
+
+	// Photo - The static photo to send. Pass a file_id to send a file that exists on the Telegram servers
+	// (recommended) or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under
+	// <file_attach_name> name. More information on Sending Files » (https://core.telegram.org/bots/api#sending-files).
+	// Sending live photos by a URL is currently unsupported.
+	Photo InputFile `json:"photo"`
+}
+
+// MediaType returns InputPaidMedia type
+func (i *InputPaidMediaLivePhoto) MediaType() string {
+	return PaidMediaTypeLivePhoto
+}
+
+// MediaFile returns InputPaidMedia file
+func (i *InputPaidMediaLivePhoto) MediaFile() InputFile {
+	return i.Media
+}
+
+func (i *InputPaidMediaLivePhoto) iInputPaidMedia() {}
+
+func (i *InputPaidMediaLivePhoto) fileParameters() map[string]telegoapi.NamedReader {
+	fp := make(map[string]telegoapi.NamedReader)
+
+	i.Media.needAttach = true
+	fp["media"] = i.Media.File
+	i.Photo.needAttach = true
+	fp["photo"] = i.Photo.File
 
 	return fp
 }

--- a/types_setters.go
+++ b/types_setters.go
@@ -72,6 +72,12 @@ func (i *InputPollOption) WithTextEntities(textEntities ...MessageEntity) *Input
 	return i
 }
 
+// WithMedia adds media parameter
+func (i *InputPollOption) WithMedia(media InputPollOptionMedia) *InputPollOption {
+	i.Media = media
+	return i
+}
+
 // WithID adds ID parameter
 func (i *InputChecklistTask) WithID(iD int) *InputChecklistTask {
 	i.ID = iD
@@ -796,6 +802,138 @@ func (i *InputPaidMediaVideo) WithDuration(duration int) *InputPaidMediaVideo {
 // WithSupportsStreaming adds supports streaming parameter
 func (i *InputPaidMediaVideo) WithSupportsStreaming() *InputPaidMediaVideo {
 	i.SupportsStreaming = true
+	return i
+}
+
+// WithMedia adds media parameter
+func (i *InputPaidMediaLivePhoto) WithMedia(media InputFile) *InputPaidMediaLivePhoto {
+	i.Media = media
+	return i
+}
+
+// WithPhoto adds photo parameter
+func (i *InputPaidMediaLivePhoto) WithPhoto(photo InputFile) *InputPaidMediaLivePhoto {
+	i.Photo = photo
+	return i
+}
+
+// WithMedia adds media parameter
+func (i *InputMediaLivePhoto) WithMedia(media InputFile) *InputMediaLivePhoto {
+	i.Media = media
+	return i
+}
+
+// WithPhoto adds photo parameter
+func (i *InputMediaLivePhoto) WithPhoto(photo InputFile) *InputMediaLivePhoto {
+	i.Photo = photo
+	return i
+}
+
+// WithCaption adds caption parameter
+func (i *InputMediaLivePhoto) WithCaption(caption string) *InputMediaLivePhoto {
+	i.Caption = caption
+	return i
+}
+
+// WithParseMode adds parse mode parameter
+func (i *InputMediaLivePhoto) WithParseMode(parseMode string) *InputMediaLivePhoto {
+	i.ParseMode = parseMode
+	return i
+}
+
+// WithCaptionEntities adds caption entities parameter
+func (i *InputMediaLivePhoto) WithCaptionEntities(captionEntities ...MessageEntity) *InputMediaLivePhoto {
+	i.CaptionEntities = captionEntities
+	return i
+}
+
+// WithShowCaptionAboveMedia adds show caption above media parameter
+func (i *InputMediaLivePhoto) WithShowCaptionAboveMedia() *InputMediaLivePhoto {
+	i.ShowCaptionAboveMedia = true
+	return i
+}
+
+// WithHasSpoiler adds has spoiler parameter
+func (i *InputMediaLivePhoto) WithHasSpoiler() *InputMediaLivePhoto {
+	i.HasSpoiler = true
+	return i
+}
+
+// WithLatitude adds latitude parameter
+func (i *InputMediaLocation) WithLatitude(latitude float64) *InputMediaLocation {
+	i.Latitude = latitude
+	return i
+}
+
+// WithLongitude adds longitude parameter
+func (i *InputMediaLocation) WithLongitude(longitude float64) *InputMediaLocation {
+	i.Longitude = longitude
+	return i
+}
+
+// WithHorizontalAccuracy adds horizontal accuracy parameter
+func (i *InputMediaLocation) WithHorizontalAccuracy(horizontalAccuracy float64) *InputMediaLocation {
+	i.HorizontalAccuracy = horizontalAccuracy
+	return i
+}
+
+// WithMedia adds media parameter
+func (i *InputMediaSticker) WithMedia(media InputFile) *InputMediaSticker {
+	i.Media = media
+	return i
+}
+
+// WithEmoji adds emoji parameter
+func (i *InputMediaSticker) WithEmoji(emoji string) *InputMediaSticker {
+	i.Emoji = emoji
+	return i
+}
+
+// WithLatitude adds latitude parameter
+func (i *InputMediaVenue) WithLatitude(latitude float64) *InputMediaVenue {
+	i.Latitude = latitude
+	return i
+}
+
+// WithLongitude adds longitude parameter
+func (i *InputMediaVenue) WithLongitude(longitude float64) *InputMediaVenue {
+	i.Longitude = longitude
+	return i
+}
+
+// WithTitle adds title parameter
+func (i *InputMediaVenue) WithTitle(title string) *InputMediaVenue {
+	i.Title = title
+	return i
+}
+
+// WithAddress adds address parameter
+func (i *InputMediaVenue) WithAddress(address string) *InputMediaVenue {
+	i.Address = address
+	return i
+}
+
+// WithFoursquareID adds foursquare ID parameter
+func (i *InputMediaVenue) WithFoursquareID(foursquareID string) *InputMediaVenue {
+	i.FoursquareID = foursquareID
+	return i
+}
+
+// WithFoursquareType adds foursquare type parameter
+func (i *InputMediaVenue) WithFoursquareType(foursquareType string) *InputMediaVenue {
+	i.FoursquareType = foursquareType
+	return i
+}
+
+// WithGooglePlaceID adds google place ID parameter
+func (i *InputMediaVenue) WithGooglePlaceID(googlePlaceID string) *InputMediaVenue {
+	i.GooglePlaceID = googlePlaceID
+	return i
+}
+
+// WithGooglePlaceType adds google place type parameter
+func (i *InputMediaVenue) WithGooglePlaceType(googlePlaceType string) *InputMediaVenue {
+	i.GooglePlaceType = googlePlaceType
 	return i
 }
 

--- a/types_setters_test.go
+++ b/types_setters_test.go
@@ -35,12 +35,14 @@ func TestInputPollOption_Setters(t *testing.T) {
 	i := (&InputPollOption{}).
 		WithText("Text").
 		WithTextParseMode("TextParseMode").
-		WithTextEntities([]MessageEntity{{Type: "TextEntities"}}...)
+		WithTextEntities([]MessageEntity{{Type: "TextEntities"}}...).
+		WithMedia(&InputMediaPhoto{})
 
 	assert.Equal(t, &InputPollOption{
 		Text:          "Text",
 		TextParseMode: "TextParseMode",
 		TextEntities:  []MessageEntity{{Type: "TextEntities"}},
+		Media:         &InputMediaPhoto{},
 	}, i)
 }
 
@@ -414,6 +416,85 @@ func TestInputPaidMediaVideo_Setters(t *testing.T) {
 		Height:            3,
 		Duration:          4,
 		SupportsStreaming: true,
+	}, i)
+}
+
+func TestInputPaidMediaLivePhoto_Setters(t *testing.T) {
+	i := (&InputPaidMediaLivePhoto{}).
+		WithMedia(testInputFile).
+		WithPhoto(testInputFile)
+
+	assert.Equal(t, &InputPaidMediaLivePhoto{
+		Media: testInputFile,
+		Photo: testInputFile,
+	}, i)
+}
+
+func TestInputMediaLivePhoto_Setters(t *testing.T) {
+	i := (&InputMediaLivePhoto{}).
+		WithMedia(testInputFile).
+		WithPhoto(testInputFile).
+		WithCaption("Caption").
+		WithParseMode("ParseMode").
+		WithCaptionEntities([]MessageEntity{{Type: "CaptionEntities"}}...).
+		WithShowCaptionAboveMedia().
+		WithHasSpoiler()
+
+	assert.Equal(t, &InputMediaLivePhoto{
+		Media:                 testInputFile,
+		Photo:                 testInputFile,
+		Caption:               "Caption",
+		ParseMode:             "ParseMode",
+		CaptionEntities:       []MessageEntity{{Type: "CaptionEntities"}},
+		ShowCaptionAboveMedia: true,
+		HasSpoiler:            true,
+	}, i)
+}
+
+func TestInputMediaLocation_Setters(t *testing.T) {
+	i := (&InputMediaLocation{}).
+		WithLatitude(1.0).
+		WithLongitude(2.0).
+		WithHorizontalAccuracy(3.0)
+
+	assert.Equal(t, &InputMediaLocation{
+		Latitude:           1.0,
+		Longitude:          2.0,
+		HorizontalAccuracy: 3.0,
+	}, i)
+}
+
+func TestInputMediaSticker_Setters(t *testing.T) {
+	i := (&InputMediaSticker{}).
+		WithMedia(testInputFile).
+		WithEmoji("Emoji")
+
+	assert.Equal(t, &InputMediaSticker{
+		Media: testInputFile,
+		Emoji: "Emoji",
+	}, i)
+}
+
+func TestInputMediaVenue_Setters(t *testing.T) {
+	i := (&InputMediaVenue{}).
+		WithLatitude(1.0).
+		WithLongitude(2.0).
+		WithTitle("Title").
+		WithAddress("Address").
+		WithFoursquareID("FoursquareID").
+		WithFoursquareType("FoursquareType").
+		WithGooglePlaceID("GooglePlaceID").
+		WithGooglePlaceType("GooglePlaceType")
+
+	assert.Equal(t, &InputMediaVenue{
+		Latitude:        1.0,
+		Longitude:       2.0,
+		Title:           "Title",
+		Address:         "Address",
+		FoursquareID:    "FoursquareID",
+		FoursquareType:  "FoursquareType",
+		GooglePlaceID:   "GooglePlaceID",
+		GooglePlaceType: "GooglePlaceType",
 	}, i)
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -33,6 +33,9 @@ func TestTypesInterfaces(t *testing.T) {
 	assert.Implements(t, (*PaidMedia)(nil), &PaidMediaVideo{})
 	assert.Equal(t, PaidMediaTypeVideo, (&PaidMediaVideo{}).MediaType())
 
+	assert.Implements(t, (*PaidMedia)(nil), &PaidMediaLivePhoto{})
+	assert.Equal(t, PaidMediaTypeLivePhoto, (&PaidMediaLivePhoto{}).MediaType())
+
 	assert.Implements(t, (*PaidMedia)(nil), &paidMediaOther{})
 	assert.Equal(t, paidMediaTypeOther, (&paidMediaOther{}).MediaType())
 
@@ -171,11 +174,37 @@ func TestTypesInterfaces(t *testing.T) {
 	assert.Implements(t, (*InputMedia)(nil), &InputMediaDocument{})
 	assert.Equal(t, MediaTypeDocument, (&InputMediaDocument{}).MediaType())
 
+	assert.Implements(t, (*InputMedia)(nil), &InputMediaLivePhoto{})
+	assert.Equal(t, MediaTypeLivePhoto, (&InputMediaLivePhoto{}).MediaType())
+
+	assert.Implements(t, (*InputPollMedia)(nil), &InputMediaPhoto{})
+	assert.Implements(t, (*InputPollMedia)(nil), &InputMediaVideo{})
+	assert.Implements(t, (*InputPollMedia)(nil), &InputMediaAnimation{})
+	assert.Implements(t, (*InputPollMedia)(nil), &InputMediaAudio{})
+	assert.Implements(t, (*InputPollMedia)(nil), &InputMediaDocument{})
+	assert.Implements(t, (*InputPollMedia)(nil), &InputMediaLivePhoto{})
+	assert.Implements(t, (*InputPollMedia)(nil), &InputMediaLocation{})
+	assert.Equal(t, MediaTypeLocation, (&InputMediaLocation{}).MediaType())
+	assert.Implements(t, (*InputPollMedia)(nil), &InputMediaVenue{})
+	assert.Equal(t, MediaTypeVenue, (&InputMediaVenue{}).MediaType())
+
+	assert.Implements(t, (*InputPollOptionMedia)(nil), &InputMediaPhoto{})
+	assert.Implements(t, (*InputPollOptionMedia)(nil), &InputMediaVideo{})
+	assert.Implements(t, (*InputPollOptionMedia)(nil), &InputMediaAnimation{})
+	assert.Implements(t, (*InputPollOptionMedia)(nil), &InputMediaLivePhoto{})
+	assert.Implements(t, (*InputPollOptionMedia)(nil), &InputMediaLocation{})
+	assert.Implements(t, (*InputPollOptionMedia)(nil), &InputMediaSticker{})
+	assert.Equal(t, MediaTypeSticker, (&InputMediaSticker{}).MediaType())
+	assert.Implements(t, (*InputPollOptionMedia)(nil), &InputMediaVenue{})
+
 	assert.Implements(t, (*InputPaidMedia)(nil), &InputPaidMediaPhoto{})
 	assert.Equal(t, PaidMediaTypePhoto, (&InputPaidMediaPhoto{}).MediaType())
 
 	assert.Implements(t, (*InputPaidMedia)(nil), &InputPaidMediaVideo{})
 	assert.Equal(t, PaidMediaTypeVideo, (&InputPaidMediaVideo{}).MediaType())
+
+	assert.Implements(t, (*InputPaidMedia)(nil), &InputPaidMediaLivePhoto{})
+	assert.Equal(t, PaidMediaTypeLivePhoto, (&InputPaidMediaLivePhoto{}).MediaType())
 
 	assert.Implements(t, (*InputProfilePhoto)(nil), &InputProfilePhotoStatic{})
 	assert.Equal(t, PhotoTypeStatic, (&InputProfilePhotoStatic{}).ProfilePhotoType())
@@ -801,9 +830,10 @@ func TestTypesConstants(t *testing.T) {
 		},
 		{
 			MediaTypePhoto, MediaTypeVideo, MediaTypeAnimation, MediaTypeAudio, MediaTypeDocument,
+			MediaTypeLivePhoto, MediaTypeLocation, MediaTypeSticker, MediaTypeVenue,
 		},
 		{
-			PaidMediaTypePreview, PaidMediaTypePhoto, PaidMediaTypeVideo, paidMediaTypeOther,
+			PaidMediaTypePreview, PaidMediaTypePhoto, PaidMediaTypeVideo, PaidMediaTypeLivePhoto, paidMediaTypeOther,
 		},
 		{
 			PhotoTypeStatic, PhotoTypeAnimated,


### PR DESCRIPTION
  # :speech_balloon: Description

  Adds full support for Telegram Bot API v10.0, released 2026-05-08: https://core.telegram.org/bots/api#may-8-2026

  Split into the same atomic commits the maintainer has used for previous version bumps:

  1. Updated types to Telegram Bot API v10.0: new structs, fields, interfaces, and constants.
  2. Updated methods to Telegram Bot API v10.0: new and updated methods, plus setters.
  3. Added handler for guest message updates: telegohandler triplet for the new Update.GuestMessage variant.
  4. Updated README to Telegram Bot API v10.0: badge and TelegramLastVersion anchor.

  ## What's covered

  **Guest Mode**
  - `User.SupportsGuestQueries`
  - `Message.GuestQueryID` / `GuestBotCallerUser` / `GuestBotCallerChat`
  - `Update.GuestMessage`
  - `SentGuestMessage` type + `AnswerGuestQuery` method
  - `telegohandler.HandleGuestMessage` / `AnyGuestMessage`

  **Chat management**
  - `ChatMemberRestricted.CanReactToMessages`, `ChatPermissions.CanReactToMessages`
  - `GetChatAdministrators` `return_bots` param (method description sentence also updated to match the live docs)
  - `DeleteMessageReaction`, `DeleteAllMessageReactions`

  **Polls**
  - `Poll.Media` / `ExplanationMedia` / `MembersOnly` / `CountryCodes`
  - `PollOption.Media`, `InputPollOption.Media`
  - `SendPoll` new params: `members_only`, `country_codes`, `media`, `explanation_media`; minimum option count lowered to 1
  - New `PollMedia` struct, new `InputPollMedia` + `InputPollOptionMedia` interfaces
  - New `InputMediaLocation` / `InputMediaSticker` / `InputMediaVenue`
  - `SendPollParams.fileParameters` aggregates file uploads from `Media`, `ExplanationMedia`, and each option's `Media`

  **Live photos**
  - `LivePhoto` type
  - `Message.LivePhoto`, `ExternalReplyInfo.LivePhoto`
  - `InputMediaLivePhoto` (also a member of `InputMedia`, `InputPollMedia`, `InputPollOptionMedia`)
  - `PaidMediaLivePhoto`, `InputPaidMediaLivePhoto`
  - `SendLivePhoto` method; `EditMessageMedia` description updated; live photo accepted by `SendMediaGroup` / `EditMessageMedia` unions
  - `PaidMediaInfo.UnmarshalJSON` dispatches the new `live_photo` variant

  **General**
  - `SendMessageDraftParams.Text` is now optional; empty text uses the "Thinking..." placeholder
  - `BotAccessSettings` type
  - `GetManagedBotAccessSettings`, `SetManagedBotAccessSettings`, `GetUserPersonalChatMessages` methods

  **Generator**
  - `internal/generator/main.go`: `typeStructsSetters` now includes the 5 new structs that support setters (`InputMediaLivePhoto`, `InputMediaLocation`, `InputMediaSticker`, `InputMediaVenue`,
  `InputPaidMediaLivePhoto`).

  ## Testing

  - `task pre-commit` passed.
  - `task test:race` passed.
  - `task test:all-tags` passed for the `default` build, `sonic`, and `stdjson`.
  - Coverage on new code: telego package 94.9%, telegohandler 100%.
  - Every new method has gomock-based success and error coverage in `methods_test.go`
  - Every new params/setter struct has a `*_Setters` test.
  - Every new interface implementation has an `assert.Implements` check in `types_test.go`.
  - All new and changed methods were also smoke-tested against the live Bot API:
      - `SendPoll` with the new params, a 1-option poll, and explanation_media echo
      - `SendMessageDraft` with empty text, using the placeholder behavior
      - `GetChatAdministrators` with `return_bots`
      - `SendLivePhoto`
      - `EditMessageMedia` with `InputMediaLivePhoto`
      - `DeleteMessageReaction` and `DeleteAllMessageReactions`
      - `AnswerGuestQuery` end to end, from incoming `guest_message` to reply
      - Managed-bot creation flow: `KeyboardButtonRequestManagedBot` to `Update.ManagedBot` to `GetManagedBotAccessSettings` / `SetManagedBotAccessSettings` round-trip

  ## Compatibility

  All changes are additive. The new interfaces use unexported marker methods, so external users could not have been implementing them already. No exported field was renamed or retyped.
  
  `SendMessageDraftParams.Text` now has `omitempty` in its JSON tag, matching Telegram's relaxed requirement for that field.

  ## :monocle_face: Type of change

  - [x] New feature (non-breaking change that adds functionality)

  # :clipboard: Checklist

  - [x] My code follows the projects' style guidelines
  - [x] I performed a self-review
  - [x] I commented the code where the logic was not obvious
  - [x] I updated the documentation
  - [x] I added unit tests proving the feature works
  - [x] Feature or fix that I was working on is in releasable state