### PR TITLE
feature/telegoflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ More examples can be seen here:
 - [Echo bot (with handlers)](examples/echo_bot_with_handlers/main.go)
 - [Echo bot (handlers + webhook + graceful shutdown + docker)](https://github.com/mymmrac/echo-bot)
 - [Conversation bot (state machine)](examples/conversation_bot/main.go)
+- [Flow conversation bot (telegoflow)](examples/flow_conversation_bot/main.go)
 - [Sending files (documents, photos, media groups)](examples/sending_files/main.go)
 - [Downloading files](examples/download_file/main.go)
 - [Inline keyboard](examples/inline_keyboard/main.go)

--- a/examples/flow_conversation_bot/main.go
+++ b/examples/flow_conversation_bot/main.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/mail"
+	"os"
+	"strconv"
+
+	"github.com/mymmrac/telego"
+	tf "github.com/mymmrac/telego/telegoflow"
+	th "github.com/mymmrac/telego/telegohandler"
+	tu "github.com/mymmrac/telego/telegoutil"
+)
+
+// UserData is typed session data shared between flow steps.
+type UserData struct {
+	Name  string
+	Age   uint
+	Email string
+}
+
+func main() {
+	ctx := context.Background()
+	botToken := os.Getenv("TOKEN")
+
+	// Create Bot with debug on
+	// Note: Please keep in mind that default logger may expose sensitive information, use in development only
+	bot, err := telego.NewBot(botToken, telego.WithDefaultDebugLogger())
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Get updates channel
+	updates, _ := bot.UpdatesViaLongPolling(ctx, nil)
+
+	// Create bot handler
+	bh, _ := th.NewBotHandler(bot, updates)
+
+	// Create flow manager with in-memory storage. In production, use persistent storage to restore sessions
+	// after restarts (PostgreSQL, Redis, etc.).
+	flows := tf.NewManager(tf.NewMemoryStorage())
+
+	registration, err := newRegistrationFlow()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Commands that should work inside a flow should be registered before flow middleware.
+	bh.Handle(func(ctx *th.Context, update telego.Update) error {
+		if err := flows.Cancel(ctx, update); err != nil {
+			_, sendErr := ctx.Bot().SendMessage(ctx, tu.Message(update.Message.Chat.ChatID(), "No active conversation"))
+			return sendErr
+		}
+
+		_, err := ctx.Bot().SendMessage(ctx, tu.Message(update.Message.Chat.ChatID(), "Conversation canceled"))
+		return err
+	}, th.CommandEqual("cancel"))
+
+	bh.Handle(func(ctx *th.Context, update telego.Update) error {
+		_, err := ctx.Bot().SendMessage(ctx, tu.Message(update.Message.Chat.ChatID(), registration.Graph()))
+		return err
+	}, th.CommandEqual("graph"))
+
+	// Active sessions are handled by flow middleware. If no session is active, processing continues to next handlers.
+	bh.Use(flows.Middleware())
+
+	// Register flow and start it with /start.
+	if err = flows.Register(registration); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	bh.Handle(registration.Start, th.CommandEqual("start"))
+
+	// Fallback for regular messages when no flow is active.
+	bh.HandleMessage(func(ctx *th.Context, msg telego.Message) error {
+		_, err := ctx.Bot().SendMessage(ctx, tu.Message(
+			msg.Chat.ChatID(),
+			"Use /start to begin the flow conversation, /cancel to cancel it, or /graph to print the flow graph.",
+		))
+		return err
+	})
+
+	fmt.Println(registration.Graph())
+
+	// Stop handling updates on exit
+	defer func() { _ = bh.Stop() }()
+
+	// Start handling updates
+	_ = bh.Start()
+}
+
+func newRegistrationFlow() (*tf.Flow[UserData], error) {
+	return tf.New[UserData]("registration").
+		Steps(
+			tf.NewStep[UserData]("name").
+				Enter(func(ctx *tf.Context[UserData]) error {
+					_, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Hello stranger, what's your name?"))
+					return err
+				}).
+				Handle(func(ctx *tf.Context[UserData]) error {
+					ctx.Data().Name = ctx.Text()
+					return ctx.Go("age")
+				}, th.AnyMessageWithText()).
+				CanGo("age"),
+
+			tf.NewStep[UserData]("age").
+				Enter(func(ctx *tf.Context[UserData]) error {
+					_, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "How old are you?"))
+					return err
+				}).
+				Handle(func(ctx *tf.Context[UserData]) error {
+					age, err := strconv.ParseUint(ctx.Text(), 10, 32)
+					if err != nil || age == 0 {
+						_, err = ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Invalid age, please try again"))
+						return err
+					}
+
+					ctx.Data().Age = uint(age)
+					return ctx.Go("email")
+				}, th.AnyMessageWithText()).
+				CanGo("email"),
+
+			tf.NewStep[UserData]("email").
+				Enter(func(ctx *tf.Context[UserData]) error {
+					_, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "What's your email?"))
+					return err
+				}).
+				Handle(func(ctx *tf.Context[UserData]) error {
+					addr, err := mail.ParseAddress(ctx.Text())
+					if err != nil {
+						_, err = ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Invalid email, please try again"))
+						return err
+					}
+
+					ctx.Data().Email = addr.Address
+					return ctx.Go("confirm")
+				}, th.AnyMessageWithText()).
+				CanGo("confirm"),
+
+			tf.NewStep[UserData]("confirm").
+				Enter(func(ctx *tf.Context[UserData]) error {
+					data := ctx.Data()
+					keyboard := tu.InlineKeyboard(
+						tu.InlineKeyboardRow(
+							tu.InlineKeyboardButton("Confirm").WithCallbackData("confirm_yes"),
+							tu.InlineKeyboardButton("Start again").WithCallbackData("confirm_no"),
+						),
+					)
+
+					_, err := ctx.Bot().SendMessage(ctx, tu.Messagef(
+						ctx.ChatID(),
+						"Your name is %s, your age is %d, and your email is %s, all correct?",
+						data.Name,
+						data.Age,
+						data.Email,
+					).WithReplyMarkup(keyboard))
+					return err
+				}).
+				Handle(func(ctx *tf.Context[UserData]) error {
+					query := ctx.CallbackQuery()
+					if query == nil {
+						return nil
+					}
+
+					_ = ctx.Bot().AnswerCallbackQuery(ctx, tu.CallbackQuery(query.ID))
+
+					switch query.Data {
+					case "confirm_yes":
+						return ctx.Complete()
+					case "confirm_no":
+						return ctx.Go("name")
+					default:
+						return nil
+					}
+				}, th.AnyCallbackQuery(), th.Or(th.CallbackDataEqual("confirm_yes"), th.CallbackDataEqual("confirm_no"))).
+				Fallback(func(ctx *tf.Context[UserData]) error {
+					_, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Please use the buttons below"))
+					return err
+				}).
+				CanGo("name"),
+		).
+		StartWith("name").
+		OnComplete(func(ctx *tf.Context[UserData]) error {
+			_, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Thanks for your data!"))
+			return err
+		}).
+		Build()
+}

--- a/examples/flow_conversation_bot/main.go
+++ b/examples/flow_conversation_bot/main.go
@@ -181,7 +181,7 @@ func newRegistrationFlow() (*tf.Flow[UserData], error) {
 					_, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Please use the buttons below"))
 					return err
 				}).
-				CanGo("name"),
+				CanGo("name").CanComplete(),
 		).
 		StartWith("name").
 		OnComplete(func(ctx *tf.Context[UserData]) error {

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -9,6 +9,10 @@ require (
 	golang.ngrok.com/ngrok v1.13.0
 )
 
+// Use the local parent module so examples can import packages added in this
+// repository before they are available in the latest released telego version.
+replace github.com/mymmrac/telego => ..
+
 require (
 	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/telegoflow/README.md
+++ b/telegoflow/README.md
@@ -147,7 +147,8 @@ func main() {
                         return err
                     }
                 }, th.AnyMessageWithText()).
-                CanGo("name"),
+                CanGo("name").
+                CanComplete(),
         ).
         StartWith("name").
         OnComplete(func(ctx *tf.Context[Registration]) error {
@@ -187,6 +188,8 @@ tf.NewStep[Data]("name").
 If a handler tries to jump to a step that wasn't declared with `CanGo`, Telegoflow returns
 `TransitionNotAllowedError`. During `Build`, Telegoflow also validates that all declared transition targets exist.
 
+If a step can finish the flow with `ctx.Complete()`, declare that exit with `CanComplete()` so `Graph()` can show it.
+
 This keeps dialog graphs explicit and easier to audit.
 
 ### :chart_with_upwards_trend: Text graph
@@ -205,14 +208,15 @@ Example output:
 flow registration (start: name)
 name
 └─> age
-    ├─> email
-    │   └─> confirm (terminal)
-    └─> retry
-        └─> age (cycle)
+    └─> email
+        └─> confirm
+            ├─> exit (complete)
+            └─> name (cycle)
 ```
 
-The graph is deterministic: transitions are sorted, terminal steps are marked with `(terminal)`, and loops are marked
-with `(cycle)`. Steps that are not reachable from the start step are shown in an `unreachable` section.
+The graph is deterministic: transitions are sorted, terminal steps are marked with `(terminal)`, declared completion
+exits are marked with `exit (complete)`, and loops are marked with `(cycle)`. Steps that are not reachable from the
+start step are shown in an `unreachable` section.
 
 ### :floppy_disk: Session storage
 
@@ -301,6 +305,6 @@ flows := telegoflow.NewManager(storage, telegoflow.WithKeyFunc(func(update teleg
 
 - **Manager** stores registered flows and routes active sessions through `telegohandler` middleware.
 - **Flow** is a typed dialog graph with lifecycle hooks: `OnComplete`, `OnCancel`, `OnTimeout`, and `OnError`.
-- **Step** is a state in the graph. It can have `Enter`, input `Handle` routes, `Fallback`, middleware, and `CanGo` transitions.
+- **Step** is a state in the graph. It can have `Enter`, input `Handle` routes, `Fallback`, middleware, `CanGo` transitions, and `CanComplete` exits.
 - **Context** embeds `*telegohandler.Context` and adds flow helpers: `Data`, `Go`, `Stay`, `Complete`, `Cancel`, `Message`, `CallbackQuery`, `ChatID`, and `UserID`.
 - **Storage** persists the current step and typed data encoded as JSON.

--- a/telegoflow/README.md
+++ b/telegoflow/README.md
@@ -1,0 +1,306 @@
+# Telegoflow • Typed Conversations for Telego
+
+Telegoflow is a stateful conversation builder for [`telego`](https://github.com/mymmrac/telego).
+It helps build multi-step dialogs as controlled flows with typed session data, explicit transitions, storage-backed
+state, and native integration with [`telegohandler`](../telegohandler).
+
+> Note: Telegoflow is an optional high-level package. It does not replace `telegohandler`; it works on top of it as
+> middleware and uses the same predicates.
+
+### :clipboard: Table Of Content
+
+<details>
+<summary>Click to show • hide</summary>
+
+- [:zap: Getting Started](#zap-getting-started)
+    - [:jigsaw: Basic setup](#jigsaw-basic-setup)
+    - [:left_right_arrow: Controlled transitions](#left_right_arrow-controlled-transitions)
+    - [:chart_with_upwards_trend: Text graph](#chart_with_upwards_trend-text-graph)
+    - [:floppy_disk: Session storage](#floppy_disk-session-storage)
+    - [:hourglass_flowing_sand: Timeouts](#hourglass_flowing_sand-timeouts)
+    - [:no_entry_sign: Canceling flows](#no_entry_sign-canceling-flows)
+    - [:gear: Custom session keys](#gear-custom-session-keys)
+- [:bricks: Core Concepts](#bricks-core-concepts)
+- [:test_tube: Testing](#test_tube-testing)
+
+</details>
+
+## :zap: Getting Started
+
+[▲ Go Up ▲](#telegoflow--typed-conversations-for-telego)
+
+### :jigsaw: Basic setup
+
+Telegoflow plugs into `telegohandler` as middleware. Register global commands that should interrupt dialogs first,
+then add flow middleware, then register flow start handlers.
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "net/mail"
+    "os"
+    "strconv"
+
+    "github.com/mymmrac/telego"
+    tf "github.com/mymmrac/telego/telegoflow"
+    th "github.com/mymmrac/telego/telegohandler"
+    tu "github.com/mymmrac/telego/telegoutil"
+)
+
+type Registration struct {
+    Name  string
+    Age   uint
+    Email string
+}
+
+func main() {
+    ctx := context.Background()
+    botToken := os.Getenv("TOKEN")
+
+    bot, err := telego.NewBot(botToken, telego.WithDefaultDebugLogger())
+    if err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
+
+    updates, _ := bot.UpdatesViaLongPolling(ctx, nil)
+    bh, _ := th.NewBotHandler(bot, updates)
+
+    flows := tf.NewManager(tf.NewMemoryStorage())
+
+    // Commands like /cancel should be registered before flow middleware.
+    bh.Handle(func(ctx *th.Context, update telego.Update) error {
+        return flows.Cancel(ctx, update)
+    }, th.CommandEqual("cancel"))
+
+    // Active sessions are routed by this middleware.
+    bh.Use(flows.Middleware())
+
+    registration, err := tf.New[Registration]("registration").
+        Steps(
+            tf.NewStep[Registration]("name").
+                Enter(func(ctx *tf.Context[Registration]) error {
+                    _, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "What's your name?"))
+                    return err
+                }).
+                Handle(func(ctx *tf.Context[Registration]) error {
+                    ctx.Data().Name = ctx.Text()
+                    return ctx.Go("age")
+                }, th.AnyMessageWithText()).
+                CanGo("age"),
+
+            tf.NewStep[Registration]("age").
+                Enter(func(ctx *tf.Context[Registration]) error {
+                    _, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "How old are you?"))
+                    return err
+                }).
+                Handle(func(ctx *tf.Context[Registration]) error {
+                    age, err := strconv.ParseUint(ctx.Text(), 10, 32)
+                    if err != nil || age == 0 {
+                        _, err = ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Invalid age, please try again"))
+                        return err
+                    }
+
+                    ctx.Data().Age = uint(age)
+                    return ctx.Go("email")
+                }, th.AnyMessageWithText()).
+                CanGo("email"),
+
+            tf.NewStep[Registration]("email").
+                Enter(func(ctx *tf.Context[Registration]) error {
+                    _, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "What's your email?"))
+                    return err
+                }).
+                Handle(func(ctx *tf.Context[Registration]) error {
+                    addr, err := mail.ParseAddress(ctx.Text())
+                    if err != nil {
+                        _, err = ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Invalid email, please try again"))
+                        return err
+                    }
+
+                    ctx.Data().Email = addr.Address
+                    return ctx.Go("confirm")
+                }, th.AnyMessageWithText()).
+                CanGo("confirm"),
+
+            tf.NewStep[Registration]("confirm").
+                Enter(func(ctx *tf.Context[Registration]) error {
+                    data := ctx.Data()
+                    _, err := ctx.Bot().SendMessage(ctx, tu.Messagef(
+                        ctx.ChatID(),
+                        "Your name is %s, your age is %d, and your email is %s. Confirm? (Y/N)",
+                        data.Name, data.Age, data.Email,
+                    ))
+                    return err
+                }).
+                Handle(func(ctx *tf.Context[Registration]) error {
+                    switch ctx.Text() {
+                    case "Y", "y":
+                        return ctx.Complete()
+                    case "N", "n":
+                        return ctx.Go("name")
+                    default:
+                        _, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Please answer Y or N"))
+                        return err
+                    }
+                }, th.AnyMessageWithText()).
+                CanGo("name"),
+        ).
+        StartWith("name").
+        OnComplete(func(ctx *tf.Context[Registration]) error {
+            _, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Thanks for your data!"))
+            return err
+        }).
+        Build()
+    if err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
+
+    _ = flows.Register(registration)
+
+    // Start command is checked only when there is no active session.
+    bh.Handle(registration.Start, th.CommandEqual("register"))
+
+    defer func() { _ = bh.Stop() }()
+    _ = bh.Start()
+}
+```
+
+### :left_right_arrow: Controlled transitions
+
+[▲ Go Up ▲](#telegoflow--typed-conversations-for-telego)
+
+Each step declares where it can go:
+
+```go
+tf.NewStep[Data]("name").
+    Handle(func(ctx *tf.Context[Data]) error {
+        return ctx.Go("age")
+    }).
+    CanGo("age")
+```
+
+If a handler tries to jump to a step that wasn't declared with `CanGo`, Telegoflow returns
+`TransitionNotAllowedError`. During `Build`, Telegoflow also validates that all declared transition targets exist.
+
+This keeps dialog graphs explicit and easier to audit.
+
+### :chart_with_upwards_trend: Text graph
+
+[▲ Go Up ▲](#telegoflow--typed-conversations-for-telego)
+
+A built flow can print its transition graph for quick visual analysis:
+
+```go
+fmt.Println(registration.Graph())
+```
+
+Example output:
+
+```text
+flow registration (start: name)
+name
+└─> age
+    ├─> email
+    │   └─> confirm (terminal)
+    └─> retry
+        └─> age (cycle)
+```
+
+The graph is deterministic: transitions are sorted, terminal steps are marked with `(terminal)`, and loops are marked
+with `(cycle)`. Steps that are not reachable from the start step are shown in an `unreachable` section.
+
+### :floppy_disk: Session storage
+
+[▲ Go Up ▲](#telegoflow--typed-conversations-for-telego)
+
+Flow sessions are saved through the `Storage` interface:
+
+```go
+type Storage interface {
+    LoadSession(ctx context.Context, key telegoflow.SessionKey) (*telegoflow.SessionState, bool, error)
+    SaveSession(ctx context.Context, session *telegoflow.SessionState) error
+    DeleteSession(ctx context.Context, key telegoflow.SessionKey) error
+}
+```
+
+Telegoflow includes `NewMemoryStorage` for development, tests, and simple bots:
+
+```go
+flows := telegoflow.NewManager(telegoflow.NewMemoryStorage())
+```
+
+For production, implement `Storage` with Redis, PostgreSQL, or another persistent backend. Session data is stored as
+JSON in `SessionState.Data`, so a new bot process can restore and continue the dialog as long as it registers a flow
+with the same ID and step IDs.
+
+### :hourglass_flowing_sand: Timeouts
+
+[▲ Go Up ▲](#telegoflow--typed-conversations-for-telego)
+
+Use `WithTimeout` to expire inactive sessions:
+
+```go
+flow, err := telegoflow.New[Data]("settings").
+    Steps(...).
+    WithTimeout(30 * time.Minute).
+    OnTimeout(func(ctx *telegoflow.Context[Data]) error {
+        _, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Session expired"))
+        return err
+    }).
+    Build()
+```
+
+When the next update for an expired session arrives, Telegoflow runs `OnTimeout` and deletes the session.
+
+### :no_entry_sign: Canceling flows
+
+[▲ Go Up ▲](#telegoflow--typed-conversations-for-telego)
+
+Register cancel commands before `flows.Middleware()` so they can interrupt an active session:
+
+```go
+bh.Handle(func(ctx *th.Context, update telego.Update) error {
+    return flows.Cancel(ctx, update)
+}, th.CommandEqual("cancel"))
+
+bh.Use(flows.Middleware())
+```
+
+A flow can also cancel itself from any handler:
+
+```go
+return ctx.Cancel()
+```
+
+### :gear: Custom session keys
+
+[▲ Go Up ▲](#telegoflow--typed-conversations-for-telego)
+
+By default, sessions are scoped by `chat_id:user_id`. This means the same user can have independent sessions in private
+chats and groups.
+
+You can override this behavior:
+
+```go
+flows := telegoflow.NewManager(storage, telegoflow.WithKeyFunc(func(update telego.Update) (telegoflow.SessionKey, bool) {
+    if update.Message == nil || update.Message.From == nil {
+        return telegoflow.SessionKey{}, false
+    }
+    return telegoflow.SessionKey{ChatID: update.Message.Chat.ID, UserID: update.Message.From.ID}, true
+}))
+```
+
+## :bricks: Core Concepts
+
+[▲ Go Up ▲](#telegoflow--typed-conversations-for-telego)
+
+- **Manager** stores registered flows and routes active sessions through `telegohandler` middleware.
+- **Flow** is a typed dialog graph with lifecycle hooks: `OnComplete`, `OnCancel`, `OnTimeout`, and `OnError`.
+- **Step** is a state in the graph. It can have `Enter`, input `Handle` routes, `Fallback`, middleware, and `CanGo` transitions.
+- **Context** embeds `*telegohandler.Context` and adds flow helpers: `Data`, `Go`, `Stay`, `Complete`, `Cancel`, `Message`, `CallbackQuery`, `ChatID`, and `UserID`.
+- **Storage** persists the current step and typed data encoded as JSON.

--- a/telegoflow/builder.go
+++ b/telegoflow/builder.go
@@ -1,0 +1,117 @@
+package telegoflow
+
+import "time"
+
+// Builder provides a fluent API for constructing a typed flow.
+type Builder[T any] struct {
+	id          string
+	steps       []*Step[T]
+	startStep   string
+	timeout     time.Duration
+	middlewares []Middleware[T]
+	onComplete  Handler[T]
+	onCancel    Handler[T]
+	onTimeout   Handler[T]
+	onError     ErrorHandler[T]
+}
+
+// New creates a builder for a typed flow.
+func New[T any](id string) *Builder[T] {
+	return &Builder[T]{id: id}
+}
+
+// Steps adds one or more steps to the flow.
+func (b *Builder[T]) Steps(steps ...*Step[T]) *Builder[T] {
+	b.steps = append(b.steps, steps...)
+	return b
+}
+
+// StartWith sets the initial step.
+//
+// If StartWith isn't called, the first added step is used.
+func (b *Builder[T]) StartWith(stepID string) *Builder[T] {
+	b.startStep = stepID
+	return b
+}
+
+// WithTimeout sets the session timeout for this flow.
+func (b *Builder[T]) WithTimeout(timeout time.Duration) *Builder[T] {
+	b.timeout = timeout
+	return b
+}
+
+// Use adds middleware for all steps in this flow.
+func (b *Builder[T]) Use(middlewares ...Middleware[T]) *Builder[T] {
+	b.middlewares = append(b.middlewares, middlewares...)
+	return b
+}
+
+// OnComplete sets a hook called when the flow completes.
+func (b *Builder[T]) OnComplete(handler Handler[T]) *Builder[T] {
+	b.onComplete = handler
+	return b
+}
+
+// OnCancel sets a hook called when the flow is canceled.
+func (b *Builder[T]) OnCancel(handler Handler[T]) *Builder[T] {
+	b.onCancel = handler
+	return b
+}
+
+// OnTimeout sets a hook called when the flow session expires.
+func (b *Builder[T]) OnTimeout(handler Handler[T]) *Builder[T] {
+	b.onTimeout = handler
+	return b
+}
+
+// OnError sets a hook called when a step handler returns an error.
+func (b *Builder[T]) OnError(handler ErrorHandler[T]) *Builder[T] {
+	b.onError = handler
+	return b
+}
+
+// Build validates and creates a flow.
+func (b *Builder[T]) Build() (*Flow[T], error) {
+	if len(b.steps) == 0 {
+		return nil, ErrEmptyFlow
+	}
+
+	steps := make(map[string]*Step[T], len(b.steps))
+	for _, step := range b.steps {
+		if step == nil || step.id == "" {
+			return nil, StepNotFoundError{FlowID: b.id}
+		}
+		if _, ok := steps[step.id]; ok {
+			return nil, DuplicateStepError{StepID: step.id}
+		}
+		steps[step.id] = step
+	}
+
+	startStep := b.startStep
+	if startStep == "" {
+		startStep = b.steps[0].id
+	}
+	if _, ok := steps[startStep]; !ok {
+		return nil, InvalidStartStepError{FlowID: b.id, StepID: startStep}
+	}
+
+	for _, step := range steps {
+		for to := range step.canGo {
+			if _, ok := steps[to]; !ok {
+				return nil, InvalidTransitionError{FlowID: b.id, From: step.id, To: to}
+			}
+		}
+	}
+
+	return &Flow[T]{
+		id:          b.id,
+		steps:       steps,
+		startStep:   startStep,
+		timeout:     b.timeout,
+		middlewares: b.middlewares,
+		onComplete:  b.onComplete,
+		onCancel:    b.onCancel,
+		onTimeout:   b.onTimeout,
+		onError:     b.onError,
+	}, nil
+}

--- a/telegoflow/builder_test.go
+++ b/telegoflow/builder_test.go
@@ -1,0 +1,148 @@
+package telegoflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_Build(t *testing.T) {
+	t.Run("empty_flow", func(t *testing.T) {
+		flow, err := New[testData]("empty").Build()
+
+		require.ErrorIs(t, err, ErrEmptyFlow)
+		assert.Nil(t, flow)
+	})
+
+	t.Run("nil_step", func(t *testing.T) {
+		flow, err := New[testData]("flow").Steps(nil).Build()
+
+		var stepErr StepNotFoundError
+		require.ErrorAs(t, err, &stepErr)
+		assert.Equal(t, "flow", stepErr.FlowID)
+		assert.Nil(t, flow)
+	})
+
+	t.Run("empty_step_id", func(t *testing.T) {
+		flow, err := New[testData]("flow").Steps(NewStep[testData]("")).Build()
+
+		var stepErr StepNotFoundError
+		require.ErrorAs(t, err, &stepErr)
+		assert.Equal(t, "flow", stepErr.FlowID)
+		assert.Nil(t, flow)
+	})
+
+	t.Run("duplicate_step", func(t *testing.T) {
+		flow, err := New[testData]("flow").
+			Steps(NewStep[testData]("same"), NewStep[testData]("same")).
+			Build()
+
+		var duplicateErr DuplicateStepError
+		require.ErrorAs(t, err, &duplicateErr)
+		assert.Equal(t, "same", duplicateErr.StepID)
+		assert.Nil(t, flow)
+	})
+
+	t.Run("invalid_start_step", func(t *testing.T) {
+		flow, err := New[testData]("flow").
+			Steps(NewStep[testData]("start")).
+			StartWith("missing").
+			Build()
+
+		var startErr InvalidStartStepError
+		require.ErrorAs(t, err, &startErr)
+		assert.Equal(t, "flow", startErr.FlowID)
+		assert.Equal(t, "missing", startErr.StepID)
+		assert.Nil(t, flow)
+	})
+
+	t.Run("invalid_transition", func(t *testing.T) {
+		flow, err := New[testData]("flow").
+			Steps(NewStep[testData]("start").CanGo("missing")).
+			Build()
+
+		var transitionErr InvalidTransitionError
+		require.ErrorAs(t, err, &transitionErr)
+		assert.Equal(t, "flow", transitionErr.FlowID)
+		assert.Equal(t, "start", transitionErr.From)
+		assert.Equal(t, "missing", transitionErr.To)
+		assert.Nil(t, flow)
+	})
+
+	t.Run("success_default_start", func(t *testing.T) {
+		flow, err := New[testData]("flow").
+			Steps(
+				NewStep[testData]("start").CanGo("finish"),
+				NewStep[testData]("finish"),
+			).
+			WithTimeout(time.Minute).
+			Build()
+
+		require.NoError(t, err)
+		require.NotNil(t, flow)
+		assert.Equal(t, "flow", flow.ID())
+		assert.Equal(t, "start", flow.startStepID())
+		assert.Equal(t, time.Minute, flow.timeoutDuration())
+	})
+
+	t.Run("success_explicit_start", func(t *testing.T) {
+		flow, err := New[testData]("flow").
+			Steps(NewStep[testData]("first"), NewStep[testData]("second")).
+			StartWith("second").
+			Build()
+
+		require.NoError(t, err)
+		require.NotNil(t, flow)
+		assert.Equal(t, "second", flow.startStepID())
+	})
+}
+
+func TestStep_BuilderMethods(t *testing.T) {
+	step := NewStep[testData]("step")
+	enter := Handler[testData](func(_ *Context[testData]) error { return nil })
+	handle := Handler[testData](func(_ *Context[testData]) error { return nil })
+	fallback := Handler[testData](func(_ *Context[testData]) error { return nil })
+	mw := Middleware[testData](func(next Handler[testData]) Handler[testData] { return next })
+
+	returned := step.Enter(enter).
+		Handle(handle).
+		Fallback(fallback).
+		Use(mw).
+		CanGo("next")
+
+	assert.Same(t, step, returned)
+	assert.Equal(t, "step", step.ID())
+	assert.NotNil(t, step.enter)
+	require.Len(t, step.routes, 1)
+	assert.NotNil(t, step.routes[0].handler)
+	assert.NotNil(t, step.fallback)
+	require.Len(t, step.middlewares, 1)
+	assert.True(t, step.allows("next"))
+	assert.False(t, step.allows("missing"))
+	assert.Empty(t, (*Step[testData])(nil).ID())
+}
+
+func TestFlow_StartBeforeRegister(t *testing.T) {
+	flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+	require.NoError(t, err)
+
+	err = flow.Start(nil, messageUpdate("/start"))
+
+	var unregisteredErr FlowNotRegisteredError
+	require.ErrorAs(t, err, &unregisteredErr)
+	assert.Equal(t, "flow", unregisteredErr.FlowID)
+}
+
+func TestFlow_EncodeInitialDataTypeMismatch(t *testing.T) {
+	flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+	require.NoError(t, err)
+
+	err = flow.encodeInitialData("wrong", &SessionState{})
+
+	var dataErr SessionDataError
+	require.ErrorAs(t, err, &dataErr)
+	assert.Equal(t, "flow", dataErr.FlowID)
+	assert.ErrorIs(t, dataErr.Unwrap(), errInvalidInitialData)
+}

--- a/telegoflow/builder_test.go
+++ b/telegoflow/builder_test.go
@@ -110,7 +110,8 @@ func TestStep_BuilderMethods(t *testing.T) {
 		Handle(handle).
 		Fallback(fallback).
 		Use(mw).
-		CanGo("next")
+		CanGo("next").
+		CanComplete()
 
 	assert.Same(t, step, returned)
 	assert.Equal(t, "step", step.ID())
@@ -120,6 +121,7 @@ func TestStep_BuilderMethods(t *testing.T) {
 	assert.NotNil(t, step.fallback)
 	require.Len(t, step.middlewares, 1)
 	assert.True(t, step.allows("next"))
+	assert.True(t, step.canComplete)
 	assert.False(t, step.allows("missing"))
 	assert.Empty(t, (*Step[testData])(nil).ID())
 }

--- a/telegoflow/context.go
+++ b/telegoflow/context.go
@@ -1,0 +1,163 @@
+package telegoflow
+
+import (
+	"encoding/json"
+
+	"github.com/mymmrac/telego"
+	th "github.com/mymmrac/telego/telegohandler"
+)
+
+// Context is passed to flow handlers.
+//
+// It embeds [telegohandler.Context], so handlers can use Bot, deadlines,
+// cancellation, and values exactly like regular telegohandler handlers.
+type Context[T any] struct {
+	*th.Context
+
+	manager *Manager
+	flow    *Flow[T]
+	update  telego.Update
+	session *SessionState
+	data    *T
+	done    bool
+}
+
+// Update returns the update currently handled by the flow.
+func (c *Context[T]) Update() telego.Update {
+	return c.update
+}
+
+// Data returns typed session data.
+func (c *Context[T]) Data() *T {
+	return c.data
+}
+
+// FlowID returns the current flow ID.
+func (c *Context[T]) FlowID() string {
+	return c.flow.id
+}
+
+// StepID returns the current step ID.
+func (c *Context[T]) StepID() string {
+	return c.session.CurrentStep
+}
+
+// SessionKey returns the current session key.
+func (c *Context[T]) SessionKey() SessionKey {
+	return c.session.Key
+}
+
+// UserID returns the user ID part of the current session key.
+func (c *Context[T]) UserID() int64 {
+	return c.session.Key.UserID
+}
+
+// ChatID returns the chat ID part of the current session key.
+func (c *Context[T]) ChatID() telego.ChatID {
+	return telego.ChatID{ID: c.session.Key.ChatID}
+}
+
+// Message returns the message carried by the current update, if any.
+func (c *Context[T]) Message() *telego.Message {
+	switch {
+	case c.update.Message != nil:
+		return c.update.Message
+	case c.update.EditedMessage != nil:
+		return c.update.EditedMessage
+	case c.update.BusinessMessage != nil:
+		return c.update.BusinessMessage
+	case c.update.EditedBusinessMessage != nil:
+		return c.update.EditedBusinessMessage
+	case c.update.GuestMessage != nil:
+		return c.update.GuestMessage
+	case c.update.CallbackQuery != nil && c.update.CallbackQuery.Message != nil:
+		return c.update.CallbackQuery.Message.Message()
+	default:
+		return nil
+	}
+}
+
+// CallbackQuery returns the callback query carried by the current update, if any.
+func (c *Context[T]) CallbackQuery() *telego.CallbackQuery {
+	return c.update.CallbackQuery
+}
+
+// Text returns message text from the current update, if any.
+func (c *Context[T]) Text() string {
+	msg := c.Message()
+	if msg == nil {
+		return ""
+	}
+	return msg.Text
+}
+
+// Go transitions to another step and executes its enter handler.
+func (c *Context[T]) Go(stepID string) error {
+	currentStep, ok := c.flow.steps[c.session.CurrentStep]
+	if !ok {
+		return StepNotFoundError{FlowID: c.flow.id, StepID: c.session.CurrentStep}
+	}
+	if !currentStep.allows(stepID) {
+		return TransitionNotAllowedError{FlowID: c.flow.id, From: c.session.CurrentStep, To: stepID}
+	}
+	if _, ok = c.flow.steps[stepID]; !ok {
+		return StepNotFoundError{FlowID: c.flow.id, StepID: stepID}
+	}
+
+	c.session.CurrentStep = stepID
+	c.session.UpdatedAt = c.manager.now()
+	if err := c.save(); err != nil {
+		return err
+	}
+
+	if err := c.flow.enterStep(c.Context, c.update, c.session, c.data); err != nil {
+		return err
+	}
+
+	_, exists, err := c.manager.storage.LoadSession(c.Context.Context(), c.session.Key)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		c.done = true
+	}
+	return nil
+}
+
+// Stay persists typed data and keeps the session on the current step.
+func (c *Context[T]) Stay() error {
+	c.session.UpdatedAt = c.manager.now()
+	return c.save()
+}
+
+// Complete completes the flow, runs its completion hook, and deletes the session.
+func (c *Context[T]) Complete() error {
+	c.done = true
+	if c.flow.onComplete != nil {
+		if err := c.flow.onComplete(c); err != nil {
+			return err
+		}
+	}
+	return c.manager.storage.DeleteSession(c.Context.Context(), c.session.Key)
+}
+
+// Cancel cancels the flow, runs its cancellation hook, and deletes the session.
+func (c *Context[T]) Cancel() error {
+	c.done = true
+	if c.flow.onCancel != nil {
+		if err := c.flow.onCancel(c); err != nil {
+			return err
+		}
+	}
+	return c.manager.storage.DeleteSession(c.Context.Context(), c.session.Key)
+}
+
+func (c *Context[T]) save() error {
+	data, err := json.Marshal(c.data)
+	if err != nil {
+		return SessionDataError{FlowID: c.flow.id, Err: err}
+	}
+
+	c.session.Data = data
+	return c.manager.storage.SaveSession(c.Context.Context(), c.session)
+}

--- a/telegoflow/context_key_storage_test.go
+++ b/telegoflow/context_key_storage_test.go
@@ -1,0 +1,267 @@
+package telegoflow
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mymmrac/telego"
+	th "github.com/mymmrac/telego/telegohandler"
+)
+
+func TestContext_AccessorsAndCallback(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	var sawCallback bool
+	var sawUpdate bool
+
+	flow, err := New[testData]("flow").
+		Steps(NewStep[testData]("callback").Handle(func(ctx *Context[testData]) error {
+			sawUpdate = ctx.Update().CallbackQuery != nil
+			callback := ctx.CallbackQuery()
+			require.NotNil(t, callback)
+			assert.Equal(t, "payload", callback.Data)
+			assert.NotNil(t, ctx.Message())
+			assert.Empty(t, ctx.Text())
+			sawCallback = true
+			return ctx.Complete()
+		}, th.AnyCallbackQuery())).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+	require.NoError(t, storage.SaveSession(t.Context(), &SessionState{
+		Key:         SessionKey{ChatID: 123, UserID: 456},
+		FlowID:      "flow",
+		CurrentStep: "callback",
+		Data:        json.RawMessage(`{}`),
+	}))
+
+	require.NoError(t, handleUpdate(t, newTestGroup(manager), callbackUpdate("payload")))
+	assert.True(t, sawUpdate)
+	assert.True(t, sawCallback)
+}
+
+func TestContext_MessageVariants(t *testing.T) {
+	baseMessage := func(text string) *telego.Message {
+		return &telego.Message{
+			MessageID: 10,
+			From:      &telego.User{ID: 456},
+			Chat:      telego.Chat{ID: 123},
+			Text:      text,
+		}
+	}
+
+	tests := []struct {
+		name   string
+		update telego.Update
+		text   string
+	}{
+		{name: "message", update: telego.Update{Message: baseMessage("message")}, text: "message"},
+		{name: "edited_message", update: telego.Update{EditedMessage: baseMessage("edited")}, text: "edited"},
+		{
+			name:   "business_message",
+			update: telego.Update{BusinessMessage: baseMessage("business")},
+			text:   "business",
+		},
+		{
+			name:   "edited_business_message",
+			update: telego.Update{EditedBusinessMessage: baseMessage("edited_business")},
+			text:   "edited_business",
+		},
+		{name: "guest_message", update: telego.Update{GuestMessage: baseMessage("guest")}, text: "guest"},
+		{name: "callback_accessible_message", update: callbackUpdate("data"), text: ""},
+		{name: "no_message", update: telego.Update{Poll: &telego.Poll{ID: "poll"}}, text: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &Context[testData]{update: tt.update}
+			msg := ctx.Message()
+			if tt.text == "" {
+				assert.Empty(t, ctx.Text())
+				return
+			}
+			require.NotNil(t, msg)
+			assert.Equal(t, tt.text, ctx.Text())
+		})
+	}
+}
+
+func TestContext_GoErrors(t *testing.T) {
+	t.Run("current_step_missing", func(t *testing.T) {
+		flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+		require.NoError(t, err)
+		ctx := &Context[testData]{flow: flow, session: &SessionState{CurrentStep: "missing"}}
+
+		err = ctx.Go("start")
+
+		var stepErr StepNotFoundError
+		require.ErrorAs(t, err, &stepErr)
+		assert.Equal(t, "missing", stepErr.StepID)
+	})
+
+	t.Run("transition_not_allowed", func(t *testing.T) {
+		flow, err := New[testData]("flow").Steps(NewStep[testData]("start"), NewStep[testData]("next")).Build()
+		require.NoError(t, err)
+		ctx := &Context[testData]{flow: flow, session: &SessionState{CurrentStep: "start"}}
+
+		err = ctx.Go("next")
+
+		var transitionErr TransitionNotAllowedError
+		require.ErrorAs(t, err, &transitionErr)
+		assert.Equal(t, "start", transitionErr.From)
+		assert.Equal(t, "next", transitionErr.To)
+	})
+}
+
+func TestFlow_LifecycleErrorHooksAndMiddleware(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	var order []string
+
+	flow, err := New[testData]("flow").
+		Steps(NewStep[testData]("start").
+			Use(func(next Handler[testData]) Handler[testData] {
+				return func(ctx *Context[testData]) error {
+					order = append(order, "step_before")
+					err := next(ctx)
+					order = append(order, "step_after")
+					return err
+				}
+			}).
+			Enter(func(ctx *Context[testData]) error {
+				order = append(order, "enter")
+				return errTest
+			})).
+		Use(func(next Handler[testData]) Handler[testData] {
+			return func(ctx *Context[testData]) error {
+				order = append(order, "flow_before")
+				err := next(ctx)
+				order = append(order, "flow_after")
+				return err
+			}
+		}).
+		OnError(func(ctx *Context[testData], err error) error {
+			order = append(order, "on_error")
+			require.ErrorIs(t, err, errTest)
+			return nil
+		}).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+
+	require.NoError(t, flow.Start(&th.Context{}, messageUpdate("/start")))
+	assert.Equal(t, []string{"flow_before", "step_before", "enter", "step_after", "flow_after", "on_error"}, order)
+}
+
+func TestFlow_StartWithData(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+
+	handler := flow.StartWithData(testData{Name: "initial", Count: 7})
+	require.NoError(t, handler(&th.Context{}, messageUpdate("/start")))
+
+	_, data, ok := loadData[testData](t, storage, SessionKey{ChatID: 123, UserID: 456})
+	require.True(t, ok)
+	assert.Equal(t, testData{Name: "initial", Count: 7}, data)
+}
+
+func TestDefaultKeyFunc(t *testing.T) {
+	msg := func(chatID, userID int64) *telego.Message {
+		return &telego.Message{From: &telego.User{ID: userID}, Chat: telego.Chat{ID: chatID}}
+	}
+
+	tests := []struct {
+		name   string
+		update telego.Update
+		key    SessionKey
+		ok     bool
+	}{
+		{name: "message", update: telego.Update{Message: msg(1, 2)}, key: SessionKey{ChatID: 1, UserID: 2}, ok: true},
+		{
+			name:   "edited",
+			update: telego.Update{EditedMessage: msg(3, 4)},
+			key:    SessionKey{ChatID: 3, UserID: 4},
+			ok:     true,
+		},
+		{
+			name:   "business",
+			update: telego.Update{BusinessMessage: msg(5, 6)},
+			key:    SessionKey{ChatID: 5, UserID: 6},
+			ok:     true,
+		},
+		{
+			name:   "edited_business",
+			update: telego.Update{EditedBusinessMessage: msg(7, 8)},
+			key:    SessionKey{ChatID: 7, UserID: 8},
+			ok:     true,
+		},
+		{
+			name:   "guest",
+			update: telego.Update{GuestMessage: msg(9, 10)},
+			key:    SessionKey{ChatID: 9, UserID: 10},
+			ok:     true,
+		},
+		{name: "callback", update: callbackUpdate("data"), key: SessionKey{ChatID: 123, UserID: 456}, ok: true},
+		{name: "message_no_from", update: telego.Update{Message: &telego.Message{Chat: telego.Chat{ID: 1}}}},
+		{
+			name:   "callback_no_message",
+			update: telego.Update{CallbackQuery: &telego.CallbackQuery{From: telego.User{ID: 1}}},
+		},
+		{name: "none", update: telego.Update{Poll: &telego.Poll{ID: "poll"}}, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, ok := DefaultKeyFunc(tt.update)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.key, key)
+		})
+	}
+}
+
+func TestMemoryStorageCloneIsolationAndHelpers(t *testing.T) {
+	storage := NewMemoryStorage()
+	key := SessionKey{ChatID: 1, UserID: 2}
+	expiresAt := fixedNow().Add(time.Minute)
+	state := &SessionState{
+		Key:         key,
+		FlowID:      "flow",
+		CurrentStep: "step",
+		Data:        json.RawMessage(`{"name":"original"}`),
+		CreatedAt:   fixedNow(),
+		UpdatedAt:   fixedNow(),
+		ExpiresAt:   &expiresAt,
+	}
+	require.NoError(t, storage.SaveSession(t.Context(), state))
+
+	state.Data[9] = 'X'
+	*state.ExpiresAt = fixedNow().Add(-time.Hour)
+	loaded, ok, err := storage.LoadSession(t.Context(), key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.JSONEq(t, `{"name":"original"}`, string(loaded.Data))
+	assert.True(t, loaded.ExpiresAt.After(fixedNow()))
+
+	loaded.Data[9] = 'Y'
+	loadedAgain, ok, err := storage.LoadSession(t.Context(), key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.JSONEq(t, `{"name":"original"}`, string(loadedAgain.Data))
+
+	assert.Equal(t, "1:2", key.String())
+	assert.False(t, (*SessionState)(nil).Expired(fixedNow()))
+	assert.Nil(t, newSessionInfo(nil))
+	assert.Nil(t, cloneSession(nil))
+
+	require.NoError(t, storage.DeleteSession(t.Context(), key))
+	_, ok, err = storage.LoadSession(t.Context(), key)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/telegoflow/doc.go
+++ b/telegoflow/doc.go
@@ -1,0 +1,43 @@
+/*
+Package telegoflow provides typed conversation flows for Telego.
+
+The package is designed as a stateful layer on top of telegohandler. A flow is a
+controlled graph of steps. Each session stores the current step and typed data,
+while handlers can move between steps using Context.Go, Context.Stay,
+Context.Complete, and Context.Cancel.
+
+Typical setup:
+
+	manager := telegoflow.NewManager(telegoflow.NewMemoryStorage())
+	bh.Use(manager.Middleware())
+
+	flow, err := telegoflow.New[Registration]("registration").
+		Steps(
+			telegoflow.NewStep[Registration]("name").
+				Enter(func(ctx *telegoflow.Context[Registration]) error {
+					_, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "What's your name?"))
+					return err
+				}).
+				Handle(func(ctx *telegoflow.Context[Registration]) error {
+					ctx.Data().Name = ctx.Text()
+					return ctx.Go("done")
+				}, th.AnyMessageWithText()).
+				CanGo("done"),
+			telegoflow.NewStep[Registration]("done").
+				Enter(func(ctx *telegoflow.Context[Registration]) error {
+					_, err := ctx.Bot().SendMessage(ctx, tu.Message(ctx.ChatID(), "Thanks, "+ctx.Data().Name+"!"))
+					if err != nil {
+						return err
+					}
+					return ctx.Complete()
+				}),
+		).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	_ = manager.Register(flow)
+	bh.Handle(flow.Start, th.CommandEqual("register"))
+*/
+package telegoflow

--- a/telegoflow/edge_cases_test.go
+++ b/telegoflow/edge_cases_test.go
@@ -1,0 +1,253 @@
+package telegoflow
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mymmrac/telego"
+	th "github.com/mymmrac/telego/telegohandler"
+)
+
+type badData struct {
+	Ch chan int `json:"ch"`
+}
+
+type badSaveData struct {
+	Value any `json:"value,omitempty"`
+}
+
+type fakeFlowRunner struct {
+	id  string
+	err error
+}
+
+func (f fakeFlowRunner) ID() string                                     { return f.id }
+func (f fakeFlowRunner) Start(_ *th.Context, _ telego.Update) error     { return nil }
+func (f fakeFlowRunner) register(_ *Manager) error                      { return f.err }
+func (f fakeFlowRunner) startStepID() string                            { return "" }
+func (f fakeFlowRunner) timeoutDuration() time.Duration                 { return 0 }
+func (f fakeFlowRunner) encodeInitialData(_ any, _ *SessionState) error { return nil }
+func (f fakeFlowRunner) enterSession(_ *th.Context, _ telego.Update, _ *SessionState) error {
+	return nil
+}
+
+func (f fakeFlowRunner) handleUpdate(_ *th.Context, _ telego.Update, _ *SessionState) error {
+	return nil
+}
+
+func (f fakeFlowRunner) timeoutSession(_ *th.Context, _ telego.Update, _ *SessionState) error {
+	return nil
+}
+
+func (f fakeFlowRunner) cancelSession(_ *th.Context, _ telego.Update, _ *SessionState) error {
+	return nil
+}
+
+func TestFlow_DataEncodingErrors(t *testing.T) {
+	t.Run("initial_data_marshal_error", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		flow, err := New[badData]("flow").Steps(NewStep[badData]("start")).Build()
+		require.NoError(t, err)
+		require.NoError(t, manager.Register(flow))
+
+		err = flow.StartWithData(badData{Ch: make(chan int)})(&th.Context{}, messageUpdate("/start"))
+
+		var dataErr SessionDataError
+		require.ErrorAs(t, err, &dataErr)
+		assert.Equal(t, "flow", dataErr.FlowID)
+	})
+
+	t.Run("save_marshal_error", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		flow, err := New[badSaveData]("flow").
+			Steps(NewStep[badSaveData]("start").Handle(func(ctx *Context[badSaveData]) error {
+				ctx.Data().Value = make(chan int)
+				return nil
+			})).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, manager.Register(flow))
+		require.NoError(t, flow.Start(&th.Context{}, messageUpdate("/start")))
+
+		err = handleUpdate(t, newTestGroup(manager), messageUpdate("boom"))
+
+		var dataErr SessionDataError
+		require.ErrorAs(t, err, &dataErr)
+		assert.Equal(t, "flow", dataErr.FlowID)
+	})
+}
+
+func TestFlow_DecodeAndStepErrors(t *testing.T) {
+	t.Run("enter_session_bad_json", func(t *testing.T) {
+		flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+		require.NoError(t, err)
+
+		err = flow.enterSession(&th.Context{}, messageUpdate("/start"), &SessionState{Data: json.RawMessage(`{bad`)})
+
+		var dataErr SessionDataError
+		require.ErrorAs(t, err, &dataErr)
+	})
+
+	t.Run("handle_update_missing_step", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+		require.NoError(t, err)
+		require.NoError(t, flow.register(manager))
+
+		err = flow.handleUpdate(&th.Context{}, messageUpdate("hello"), &SessionState{
+			FlowID:      "flow",
+			CurrentStep: "missing",
+			Data:        json.RawMessage(`{}`),
+		})
+
+		var stepErr StepNotFoundError
+		require.ErrorAs(t, err, &stepErr)
+		assert.Equal(t, "missing", stepErr.StepID)
+	})
+
+	t.Run("enter_step_missing_step", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+		require.NoError(t, err)
+		require.NoError(t, flow.register(manager))
+
+		err = flow.enterStep(&th.Context{}, messageUpdate("hello"), &SessionState{CurrentStep: "missing"}, &testData{})
+
+		var stepErr StepNotFoundError
+		require.ErrorAs(t, err, &stepErr)
+		assert.Equal(t, "missing", stepErr.StepID)
+	})
+}
+
+func TestFlow_LifecycleHookErrors(t *testing.T) {
+	t.Run("on_complete_error", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		flow, err := New[testData]("flow").
+			Steps(NewStep[testData]("start").Enter(func(ctx *Context[testData]) error { return ctx.Complete() })).
+			OnComplete(func(_ *Context[testData]) error { return errTest }).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, manager.Register(flow))
+
+		err = flow.Start(&th.Context{}, messageUpdate("/start"))
+
+		require.ErrorIs(t, err, errTest)
+	})
+
+	t.Run("on_cancel_error", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		flow, err := New[testData]("flow").
+			Steps(NewStep[testData]("start").Enter(func(ctx *Context[testData]) error { return ctx.Cancel() })).
+			OnCancel(func(_ *Context[testData]) error { return errTest }).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, manager.Register(flow))
+
+		err = flow.Start(&th.Context{}, messageUpdate("/start"))
+
+		require.ErrorIs(t, err, errTest)
+	})
+
+	t.Run("on_timeout_error", func(t *testing.T) {
+		storage := NewMemoryStorage()
+		manager := NewManager(storage)
+		manager.nowFunc = fixedNow
+		flow, err := New[testData]("flow").
+			Steps(NewStep[testData]("start")).
+			OnTimeout(func(_ *Context[testData]) error { return errTest }).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, manager.Register(flow))
+		expiresAt := fixedNow().Add(-time.Second)
+		require.NoError(t, storage.SaveSession(t.Context(), &SessionState{
+			Key:         SessionKey{ChatID: 123, UserID: 456},
+			FlowID:      "flow",
+			CurrentStep: "start",
+			Data:        json.RawMessage(`{}`),
+			ExpiresAt:   &expiresAt,
+		}))
+
+		err = handleUpdate(t, newTestGroup(manager), messageUpdate("hello"))
+
+		require.ErrorIs(t, err, errTest)
+	})
+}
+
+func TestContext_GoMoreEdgeCases(t *testing.T) {
+	t.Run("target_missing_after_build", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		flow, err := New[testData]("flow").
+			Steps(NewStep[testData]("start").CanGo("next"), NewStep[testData]("next")).
+			Build()
+		require.NoError(t, err)
+		delete(flow.steps, "next")
+		ctx := &Context[testData]{
+			manager: manager,
+			flow:    flow,
+			Context: &th.Context{},
+			session: &SessionState{CurrentStep: "start"},
+		}
+
+		err = ctx.Go("next")
+
+		var stepErr StepNotFoundError
+		require.ErrorAs(t, err, &stepErr)
+		assert.Equal(t, "next", stepErr.StepID)
+	})
+
+	t.Run("load_after_go_enter_error", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		flow, err := New[testData]("flow").
+			Steps(
+				NewStep[testData]("start").CanGo("next"),
+				NewStep[testData]("next").Enter(func(_ *Context[testData]) error { return errTest }),
+			).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, manager.Register(flow))
+
+		ctx := &Context[testData]{
+			manager: manager,
+			flow:    flow,
+			Context: &th.Context{},
+			session: &SessionState{
+				Key:         SessionKey{ChatID: 123, UserID: 456},
+				FlowID:      "flow",
+				CurrentStep: "start",
+				Data:        json.RawMessage(`{}`),
+			},
+			data: &testData{},
+		}
+
+		err = ctx.Go("next")
+
+		require.ErrorIs(t, err, errTest)
+	})
+}
+
+func TestManager_OptionAndRegisterEdges(t *testing.T) {
+	t.Run("nil_storage_and_nil_key_func", func(t *testing.T) {
+		manager := NewManager(nil, WithKeyFunc(nil))
+		assert.NotNil(t, manager.storage)
+		key, ok := manager.keyFunc(messageUpdate("hello"))
+		assert.True(t, ok)
+		assert.Equal(t, SessionKey{ChatID: 123, UserID: 456}, key)
+	})
+
+	t.Run("register_error", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		err := manager.Register(fakeFlowRunner{id: "fake", err: errTest})
+
+		require.ErrorIs(t, err, errTest)
+	})
+}
+
+func TestStep_CanGoInitializesNilMap(t *testing.T) {
+	step := &Step[testData]{id: "step"}
+	step.CanGo("next")
+	assert.True(t, step.allows("next"))
+}

--- a/telegoflow/errors.go
+++ b/telegoflow/errors.go
@@ -1,0 +1,108 @@
+package telegoflow
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrEmptyFlow is returned when a flow is built without steps.
+var ErrEmptyFlow = errors.New("telego: flow must have at least one step")
+
+// NoSessionKeyError is returned when a session key can't be extracted from an update.
+type NoSessionKeyError struct{}
+
+func (e NoSessionKeyError) Error() string {
+	return "telego: flow session key not found in update"
+}
+
+// FlowNotFoundError is returned when a session references an unknown flow.
+type FlowNotFoundError struct {
+	FlowID string
+}
+
+func (e FlowNotFoundError) Error() string {
+	return fmt.Sprintf("telego: flow %q not found", e.FlowID)
+}
+
+// DuplicateFlowError is returned when a manager already has a flow with the same ID.
+type DuplicateFlowError struct {
+	FlowID string
+}
+
+func (e DuplicateFlowError) Error() string {
+	return fmt.Sprintf("telego: duplicate flow %q", e.FlowID)
+}
+
+// FlowNotRegisteredError is returned when a flow is started before it was registered in a manager.
+type FlowNotRegisteredError struct {
+	FlowID string
+}
+
+func (e FlowNotRegisteredError) Error() string {
+	return fmt.Sprintf("telego: flow %q is not registered in a manager", e.FlowID)
+}
+
+// StepNotFoundError is returned when a step is missing in the flow.
+type StepNotFoundError struct {
+	FlowID string
+	StepID string
+}
+
+func (e StepNotFoundError) Error() string {
+	return fmt.Sprintf("telego: step %q not found in flow %q", e.StepID, e.FlowID)
+}
+
+// DuplicateStepError is returned when a flow contains multiple steps with the same ID.
+type DuplicateStepError struct {
+	StepID string
+}
+
+func (e DuplicateStepError) Error() string {
+	return fmt.Sprintf("telego: duplicate step %q", e.StepID)
+}
+
+// InvalidStartStepError is returned when the configured start step doesn't exist.
+type InvalidStartStepError struct {
+	FlowID string
+	StepID string
+}
+
+func (e InvalidStartStepError) Error() string {
+	return fmt.Sprintf("telego: start step %q not found in flow %q", e.StepID, e.FlowID)
+}
+
+// InvalidTransitionError is returned when a step declares a transition to an unknown step.
+type InvalidTransitionError struct {
+	FlowID string
+	From   string
+	To     string
+}
+
+func (e InvalidTransitionError) Error() string {
+	return fmt.Sprintf("telego: transition from step %q to step %q in flow %q is invalid", e.From, e.To, e.FlowID)
+}
+
+// TransitionNotAllowedError is returned when a handler tries to jump to a step not declared by CanGo.
+type TransitionNotAllowedError struct {
+	FlowID string
+	From   string
+	To     string
+}
+
+func (e TransitionNotAllowedError) Error() string {
+	return fmt.Sprintf("telego: transition from step %q to step %q in flow %q is not allowed", e.From, e.To, e.FlowID)
+}
+
+// SessionDataError is returned when typed session data can't be encoded or decoded.
+type SessionDataError struct {
+	FlowID string
+	Err    error
+}
+
+func (e SessionDataError) Error() string {
+	return fmt.Sprintf("telego: session data error in flow %q: %v", e.FlowID, e.Err)
+}
+
+func (e SessionDataError) Unwrap() error {
+	return e.Err
+}

--- a/telegoflow/flow.go
+++ b/telegoflow/flow.go
@@ -1,0 +1,212 @@
+package telegoflow
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/mymmrac/telego"
+	th "github.com/mymmrac/telego/telegohandler"
+)
+
+// FlowRunner is implemented by typed flows and accepted by [Manager.Register].
+//
+// This interface is sealed intentionally; create values with [New] and [Builder.Build]
+// instead of implementing it manually.
+type FlowRunner interface {
+	ID() string
+	Start(ctx *th.Context, update telego.Update) error
+
+	register(manager *Manager) error
+	startStepID() string
+	timeoutDuration() time.Duration
+	encodeInitialData(data any, session *SessionState) error
+	enterSession(ctx *th.Context, update telego.Update, session *SessionState) error
+	handleUpdate(ctx *th.Context, update telego.Update, session *SessionState) error
+	timeoutSession(ctx *th.Context, update telego.Update, session *SessionState) error
+	cancelSession(ctx *th.Context, update telego.Update, session *SessionState) error
+}
+
+var errInvalidInitialData = errors.New("invalid initial flow data type")
+
+// Flow is a typed conversation graph.
+type Flow[T any] struct {
+	manager *Manager
+
+	id          string
+	steps       map[string]*Step[T]
+	startStep   string
+	timeout     time.Duration
+	middlewares []Middleware[T]
+	onComplete  Handler[T]
+	onCancel    Handler[T]
+	onTimeout   Handler[T]
+	onError     ErrorHandler[T]
+}
+
+// ID returns the flow ID.
+func (f *Flow[T]) ID() string {
+	return f.id
+}
+
+// Start starts this flow with a zero value of T as session data.
+func (f *Flow[T]) Start(ctx *th.Context, update telego.Update) error {
+	var data T
+	return f.startSession(ctx, update, data)
+}
+
+// StartWithData returns a telegohandler handler that starts this flow with the provided initial data.
+func (f *Flow[T]) StartWithData(data T) th.Handler {
+	return func(ctx *th.Context, update telego.Update) error {
+		return f.startSession(ctx, update, data)
+	}
+}
+
+func (f *Flow[T]) startSession(ctx *th.Context, update telego.Update, data T) error {
+	if f.manager == nil {
+		return FlowNotRegisteredError{FlowID: f.id}
+	}
+	return f.manager.startFlow(ctx, update, f, data)
+}
+
+func (f *Flow[T]) register(manager *Manager) error {
+	f.manager = manager
+	return nil
+}
+
+func (f *Flow[T]) startStepID() string {
+	return f.startStep
+}
+
+func (f *Flow[T]) timeoutDuration() time.Duration {
+	return f.timeout
+}
+
+func (f *Flow[T]) encodeInitialData(data any, session *SessionState) error {
+	typed, ok := data.(T)
+	if !ok {
+		return SessionDataError{FlowID: f.id, Err: errInvalidInitialData}
+	}
+
+	encoded, err := json.Marshal(typed)
+	if err != nil {
+		return SessionDataError{FlowID: f.id, Err: err}
+	}
+	session.Data = encoded
+	return nil
+}
+
+func (f *Flow[T]) enterSession(ctx *th.Context, update telego.Update, session *SessionState) error {
+	data, err := f.decodeData(session)
+	if err != nil {
+		return err
+	}
+	return f.enterStep(ctx, update, session, data)
+}
+
+func (f *Flow[T]) handleUpdate(ctx *th.Context, update telego.Update, session *SessionState) error {
+	data, err := f.decodeData(session)
+	if err != nil {
+		return err
+	}
+
+	flowCtx := f.newContext(ctx, update, session, data)
+	step, ok := f.steps[session.CurrentStep]
+	if !ok {
+		return StepNotFoundError{FlowID: f.id, StepID: session.CurrentStep}
+	}
+
+	for _, route := range step.routes {
+		if route.match(ctx.Context(), update) {
+			return f.runHandler(flowCtx, step, route.handler)
+		}
+	}
+
+	if step.fallback != nil {
+		return f.runHandler(flowCtx, step, step.fallback)
+	}
+
+	return flowCtx.Stay()
+}
+
+func (f *Flow[T]) timeoutSession(ctx *th.Context, update telego.Update, session *SessionState) error {
+	data, err := f.decodeData(session)
+	if err != nil {
+		return err
+	}
+
+	flowCtx := f.newContext(ctx, update, session, data)
+	flowCtx.done = true
+	if f.onTimeout != nil {
+		if err = f.onTimeout(flowCtx); err != nil {
+			return err
+		}
+	}
+	return f.manager.storage.DeleteSession(ctx.Context(), session.Key)
+}
+
+func (f *Flow[T]) cancelSession(ctx *th.Context, update telego.Update, session *SessionState) error {
+	data, err := f.decodeData(session)
+	if err != nil {
+		return err
+	}
+
+	flowCtx := f.newContext(ctx, update, session, data)
+	return flowCtx.Cancel()
+}
+
+func (f *Flow[T]) enterStep(ctx *th.Context, update telego.Update, session *SessionState, data *T) error {
+	flowCtx := f.newContext(ctx, update, session, data)
+	step, ok := f.steps[session.CurrentStep]
+	if !ok {
+		return StepNotFoundError{FlowID: f.id, StepID: session.CurrentStep}
+	}
+	if step.enter == nil {
+		return flowCtx.Stay()
+	}
+	return f.runHandler(flowCtx, step, step.enter)
+}
+
+func (f *Flow[T]) runHandler(ctx *Context[T], step *Step[T], handler Handler[T]) error {
+	wrapped := handler
+	for i := len(step.middlewares) - 1; i >= 0; i-- {
+		wrapped = step.middlewares[i](wrapped)
+	}
+	for i := len(f.middlewares) - 1; i >= 0; i-- {
+		wrapped = f.middlewares[i](wrapped)
+	}
+
+	err := wrapped(ctx)
+	if err != nil {
+		if f.onError != nil {
+			return f.onError(ctx, err)
+		}
+		return err
+	}
+	if ctx.done {
+		return nil
+	}
+	return ctx.Stay()
+}
+
+func (f *Flow[T]) newContext(ctx *th.Context, update telego.Update, session *SessionState, data *T) *Context[T] {
+	return &Context[T]{
+		Context: ctx,
+		manager: f.manager,
+		flow:    f,
+		update:  update,
+		session: session,
+		data:    data,
+	}
+}
+
+func (f *Flow[T]) decodeData(session *SessionState) (*T, error) {
+	data := new(T)
+	if len(session.Data) == 0 {
+		return data, nil
+	}
+	if err := json.Unmarshal(session.Data, data); err != nil {
+		return nil, SessionDataError{FlowID: f.id, Err: err}
+	}
+	return data, nil
+}

--- a/telegoflow/graph.go
+++ b/telegoflow/graph.go
@@ -10,13 +10,16 @@ const (
 	graphLast   = "└─> "
 	graphPipe   = "│   "
 	graphSpace  = "    "
+	graphExit   = "exit (complete)"
 )
 
 // Graph returns a deterministic text representation of the flow transitions.
 //
 // The graph starts from the configured start step and follows transitions
-// declared with [Step.CanGo]. Steps with no outgoing transitions are marked as
-// terminal. Cycles are marked explicitly and not expanded recursively.
+// declared with [Step.CanGo]. Steps with no outgoing transitions and no
+// declared completion are marked as terminal. Steps declared with
+// [Step.CanComplete] show an explicit flow exit. Cycles are marked explicitly
+// and not expanded recursively.
 func (f *Flow[T]) Graph() string {
 	if f == nil {
 		return ""
@@ -86,13 +89,21 @@ func (f *Flow[T]) writeGraphStep(
 	defer delete(stack, stepID)
 
 	transitions := step.transitions()
-	if len(transitions) == 0 {
+	if len(transitions) == 0 && !step.canComplete {
 		writeGraphString(builder, " (terminal)\n")
 		return
 	}
 
 	writeGraphString(builder, "\n")
 	nextPrefix := prefix + graphPrefix(connector)
+	edgeCount := len(transitions)
+	if step.canComplete {
+		edgeCount++
+		writeGraphString(builder, nextPrefix)
+		writeGraphString(builder, graphConnector(edgeCount == 1))
+		writeGraphString(builder, graphExit)
+		writeGraphString(builder, "\n")
+	}
 	for i, transition := range transitions {
 		f.writeGraphStep(builder, transition, nextPrefix, graphConnector(i == len(transitions)-1), visited, stack)
 	}

--- a/telegoflow/graph.go
+++ b/telegoflow/graph.go
@@ -1,0 +1,130 @@
+package telegoflow
+
+import (
+	"slices"
+	"strings"
+)
+
+const (
+	graphBranch = "├─> "
+	graphLast   = "└─> "
+	graphPipe   = "│   "
+	graphSpace  = "    "
+)
+
+// Graph returns a deterministic text representation of the flow transitions.
+//
+// The graph starts from the configured start step and follows transitions
+// declared with [Step.CanGo]. Steps with no outgoing transitions are marked as
+// terminal. Cycles are marked explicitly and not expanded recursively.
+func (f *Flow[T]) Graph() string {
+	if f == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	writeGraphString(&builder, "flow ")
+	writeGraphString(&builder, f.id)
+	writeGraphString(&builder, " (start: ")
+	writeGraphString(&builder, f.startStep)
+	writeGraphString(&builder, ")\n")
+
+	visited := make(map[string]bool, len(f.steps))
+	stack := make(map[string]bool, len(f.steps))
+
+	if f.startStep != "" {
+		f.writeGraphStep(&builder, f.startStep, "", "", visited, stack)
+	}
+
+	unreachable := make([]string, 0)
+	for stepID := range f.steps {
+		if !visited[stepID] {
+			unreachable = append(unreachable, stepID)
+		}
+	}
+	slices.Sort(unreachable)
+
+	if len(unreachable) > 0 {
+		writeGraphString(&builder, "\nunreachable\n")
+		for i, stepID := range unreachable {
+			f.writeGraphStep(&builder, stepID, "", graphConnector(i == len(unreachable)-1), visited, stack)
+		}
+	}
+
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func (f *Flow[T]) writeGraphStep(
+	builder *strings.Builder,
+	stepID string,
+	prefix string,
+	connector string,
+	visited map[string]bool,
+	stack map[string]bool,
+) {
+	writeGraphString(builder, prefix)
+	writeGraphString(builder, connector)
+	writeGraphString(builder, stepID)
+
+	step, ok := f.steps[stepID]
+	if !ok {
+		writeGraphString(builder, " (missing)\n")
+		return
+	}
+
+	if stack[stepID] {
+		writeGraphString(builder, " (cycle)\n")
+		return
+	}
+	if visited[stepID] {
+		writeGraphString(builder, " (visited)\n")
+		return
+	}
+
+	visited[stepID] = true
+	stack[stepID] = true
+	defer delete(stack, stepID)
+
+	transitions := step.transitions()
+	if len(transitions) == 0 {
+		writeGraphString(builder, " (terminal)\n")
+		return
+	}
+
+	writeGraphString(builder, "\n")
+	nextPrefix := prefix + graphPrefix(connector)
+	for i, transition := range transitions {
+		f.writeGraphStep(builder, transition, nextPrefix, graphConnector(i == len(transitions)-1), visited, stack)
+	}
+}
+
+func (s *Step[T]) transitions() []string {
+	transitions := make([]string, 0, len(s.canGo))
+	for stepID := range s.canGo {
+		transitions = append(transitions, stepID)
+	}
+	slices.Sort(transitions)
+	return transitions
+}
+
+func graphConnector(last bool) string {
+	if last {
+		return graphLast
+	}
+	return graphBranch
+}
+
+func graphPrefix(connector string) string {
+	switch connector {
+	case graphLast:
+		return graphSpace
+	case graphBranch:
+		return graphPipe
+	default:
+		return ""
+	}
+}
+
+func writeGraphString(builder *strings.Builder, value string) {
+	_, _ = builder.WriteString(value)
+}

--- a/telegoflow/graph_test.go
+++ b/telegoflow/graph_test.go
@@ -47,6 +47,26 @@ name
         └─> age (cycle)`, flow.Graph())
 	})
 
+	t.Run("completion_exit_and_cycle", func(t *testing.T) {
+		flow, err := New[testData]("registration").
+			Steps(
+				NewStep[testData]("name").CanGo("age"),
+				NewStep[testData]("age").CanGo("email"),
+				NewStep[testData]("email").CanGo("confirm"),
+				NewStep[testData]("confirm").CanGo("name").CanComplete(),
+			).
+			Build()
+		require.NoError(t, err)
+
+		assert.Equal(t, `flow registration (start: name)
+name
+└─> age
+    └─> email
+        └─> confirm
+            ├─> exit (complete)
+            └─> name (cycle)`, flow.Graph())
+	})
+
 	t.Run("unreachable", func(t *testing.T) {
 		flow, err := New[testData]("flow").
 			Steps(

--- a/telegoflow/graph_test.go
+++ b/telegoflow/graph_test.go
@@ -1,0 +1,72 @@
+package telegoflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlow_Graph(t *testing.T) {
+	t.Run("linear", func(t *testing.T) {
+		flow, err := New[testData]("registration").
+			Steps(
+				NewStep[testData]("name").CanGo("age"),
+				NewStep[testData]("age").CanGo("email"),
+				NewStep[testData]("email").CanGo("confirm"),
+				NewStep[testData]("confirm"),
+			).
+			Build()
+		require.NoError(t, err)
+
+		assert.Equal(t, `flow registration (start: name)
+name
+└─> age
+    └─> email
+        └─> confirm (terminal)`, flow.Graph())
+	})
+
+	t.Run("branch_cycle_and_terminal", func(t *testing.T) {
+		flow, err := New[testData]("registration").
+			Steps(
+				NewStep[testData]("name").CanGo("age"),
+				NewStep[testData]("age").CanGo("email", "retry"),
+				NewStep[testData]("email").CanGo("confirm"),
+				NewStep[testData]("retry").CanGo("age"),
+				NewStep[testData]("confirm"),
+			).
+			Build()
+		require.NoError(t, err)
+
+		assert.Equal(t, `flow registration (start: name)
+name
+└─> age
+    ├─> email
+    │   └─> confirm (terminal)
+    └─> retry
+        └─> age (cycle)`, flow.Graph())
+	})
+
+	t.Run("unreachable", func(t *testing.T) {
+		flow, err := New[testData]("flow").
+			Steps(
+				NewStep[testData]("start"),
+				NewStep[testData]("orphan").CanGo("orphan_done"),
+				NewStep[testData]("orphan_done"),
+			).
+			Build()
+		require.NoError(t, err)
+
+		assert.Equal(t, `flow flow (start: start)
+start (terminal)
+
+unreachable
+├─> orphan
+│   └─> orphan_done (terminal)
+└─> orphan_done (visited)`, flow.Graph())
+	})
+
+	t.Run("nil_flow", func(t *testing.T) {
+		assert.Empty(t, (*Flow[testData])(nil).Graph())
+	})
+}

--- a/telegoflow/key.go
+++ b/telegoflow/key.go
@@ -1,0 +1,38 @@
+package telegoflow
+
+import "github.com/mymmrac/telego"
+
+// KeyFunc extracts a session key from an update.
+type KeyFunc func(update telego.Update) (SessionKey, bool)
+
+// DefaultKeyFunc extracts a key from message-like updates and callback queries.
+//
+// The key is chat scoped and user scoped: chat_id:user_id.
+func DefaultKeyFunc(update telego.Update) (SessionKey, bool) {
+	if update.Message != nil && update.Message.From != nil {
+		return SessionKey{ChatID: update.Message.Chat.ID, UserID: update.Message.From.ID}, true
+	}
+	if update.EditedMessage != nil && update.EditedMessage.From != nil {
+		return SessionKey{ChatID: update.EditedMessage.Chat.ID, UserID: update.EditedMessage.From.ID}, true
+	}
+	if update.BusinessMessage != nil && update.BusinessMessage.From != nil {
+		return SessionKey{ChatID: update.BusinessMessage.Chat.ID, UserID: update.BusinessMessage.From.ID}, true
+	}
+	if update.EditedBusinessMessage != nil && update.EditedBusinessMessage.From != nil {
+		return SessionKey{
+			ChatID: update.EditedBusinessMessage.Chat.ID,
+			UserID: update.EditedBusinessMessage.From.ID,
+		}, true
+	}
+	if update.GuestMessage != nil && update.GuestMessage.From != nil {
+		return SessionKey{ChatID: update.GuestMessage.Chat.ID, UserID: update.GuestMessage.From.ID}, true
+	}
+	if update.CallbackQuery != nil && update.CallbackQuery.Message != nil {
+		return SessionKey{
+			ChatID: update.CallbackQuery.Message.GetChat().ID,
+			UserID: update.CallbackQuery.From.ID,
+		}, true
+	}
+
+	return SessionKey{}, false
+}

--- a/telegoflow/manager.go
+++ b/telegoflow/manager.go
@@ -1,0 +1,210 @@
+package telegoflow
+
+import (
+	"sync"
+	"time"
+
+	"github.com/mymmrac/telego"
+	th "github.com/mymmrac/telego/telegohandler"
+)
+
+// Manager coordinates flows, sessions, and telegohandler integration.
+type Manager struct {
+	storage Storage
+	keyFunc KeyFunc
+	nowFunc func() time.Time
+
+	mu    sync.Mutex
+	flows map[string]FlowRunner
+	locks map[SessionKey]*sessionLock
+}
+
+type sessionLock struct {
+	ch chan struct{}
+}
+
+// ManagerOption configures a manager.
+type ManagerOption func(manager *Manager)
+
+// WithKeyFunc configures custom session key extraction.
+func WithKeyFunc(keyFunc KeyFunc) ManagerOption {
+	return func(manager *Manager) {
+		if keyFunc != nil {
+			manager.keyFunc = keyFunc
+		}
+	}
+}
+
+// NewManager creates a flow manager.
+func NewManager(storage Storage, options ...ManagerOption) *Manager {
+	if storage == nil {
+		storage = NewMemoryStorage()
+	}
+
+	manager := &Manager{
+		storage: storage,
+		keyFunc: DefaultKeyFunc,
+		nowFunc: time.Now,
+		flows:   make(map[string]FlowRunner),
+		locks:   make(map[SessionKey]*sessionLock),
+	}
+
+	for _, option := range options {
+		option(manager)
+	}
+
+	return manager
+}
+
+// Register registers flows in the manager.
+func (m *Manager) Register(flows ...FlowRunner) error {
+	for _, flow := range flows {
+		if flow == nil {
+			continue
+		}
+		if _, ok := m.flows[flow.ID()]; ok {
+			return DuplicateFlowError{FlowID: flow.ID()}
+		}
+		if err := flow.register(m); err != nil {
+			return err
+		}
+		m.flows[flow.ID()] = flow
+	}
+	return nil
+}
+
+// Middleware returns a telegohandler middleware that routes active sessions to flows.
+//
+// If the update doesn't belong to an active session, the middleware calls ctx.Next(update).
+func (m *Manager) Middleware() th.Handler {
+	return func(ctx *th.Context, update telego.Update) error {
+		key, ok := m.keyFunc(update)
+		if !ok {
+			return ctx.Next(update)
+		}
+
+		lock := m.lockFor(key)
+		lock.lock()
+		state, exists, err := m.storage.LoadSession(ctx.Context(), key)
+		if err != nil {
+			lock.unlock()
+			return err
+		}
+		if !exists {
+			lock.unlock()
+			return ctx.Next(update)
+		}
+		defer lock.unlock()
+
+		flow, ok := m.flows[state.FlowID]
+		if !ok {
+			return FlowNotFoundError{FlowID: state.FlowID}
+		}
+		if state.Expired(m.now()) {
+			return flow.timeoutSession(ctx, update, state)
+		}
+
+		return flow.handleUpdate(ctx, update, state)
+	}
+}
+
+// Cancel cancels the active session for this update, if any.
+func (m *Manager) Cancel(ctx *th.Context, update telego.Update) error {
+	key, ok := m.keyFunc(update)
+	if !ok {
+		return NoSessionKeyError{}
+	}
+
+	lock := m.lockFor(key)
+	lock.lock()
+	defer lock.unlock()
+
+	state, exists, err := m.storage.LoadSession(ctx.Context(), key)
+	if err != nil || !exists {
+		return err
+	}
+
+	flow, ok := m.flows[state.FlowID]
+	if !ok {
+		return FlowNotFoundError{FlowID: state.FlowID}
+	}
+
+	return flow.cancelSession(ctx, update, state)
+}
+
+// ActiveSession returns information about the active session for this update, if any.
+func (m *Manager) ActiveSession(ctx *th.Context, update telego.Update) (*SessionInfo, bool, error) {
+	key, ok := m.keyFunc(update)
+	if !ok {
+		return nil, false, nil
+	}
+
+	state, exists, err := m.storage.LoadSession(ctx.Context(), key)
+	if err != nil || !exists {
+		return nil, false, err
+	}
+	if state.Expired(m.now()) {
+		return nil, false, nil
+	}
+
+	return newSessionInfo(state), true, nil
+}
+
+func (m *Manager) startFlow(ctx *th.Context, update telego.Update, flow FlowRunner, data any) error {
+	key, ok := m.keyFunc(update)
+	if !ok {
+		return NoSessionKeyError{}
+	}
+
+	lock := m.lockFor(key)
+	lock.lock()
+	defer lock.unlock()
+
+	now := m.now()
+	state := &SessionState{
+		Key:         key,
+		FlowID:      flow.ID(),
+		CurrentStep: flow.startStepID(),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if timeout := flow.timeoutDuration(); timeout > 0 {
+		expiresAt := now.Add(timeout)
+		state.ExpiresAt = &expiresAt
+	}
+
+	if err := flow.encodeInitialData(data, state); err != nil {
+		return err
+	}
+	if err := m.storage.SaveSession(ctx.Context(), state); err != nil {
+		return err
+	}
+
+	return flow.enterSession(ctx, update, state)
+}
+
+func (m *Manager) lockFor(key SessionKey) *sessionLock {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	lock, ok := m.locks[key]
+	if !ok {
+		lock = &sessionLock{ch: make(chan struct{}, 1)}
+		lock.ch <- struct{}{}
+		m.locks[key] = lock
+	}
+	return lock
+}
+
+func (m *Manager) now() time.Time {
+	return m.nowFunc()
+}
+
+func (l *sessionLock) lock() {
+	<-l.ch
+}
+
+func (l *sessionLock) unlock() {
+	l.ch <- struct{}{}
+}

--- a/telegoflow/manager_test.go
+++ b/telegoflow/manager_test.go
@@ -1,0 +1,585 @@
+package telegoflow
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mymmrac/telego"
+	th "github.com/mymmrac/telego/telegohandler"
+)
+
+func TestManager_Register(t *testing.T) {
+	manager := NewManager(NewMemoryStorage())
+	flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+	require.NoError(t, err)
+
+	t.Run("success_and_nil_ignored", func(t *testing.T) {
+		err = manager.Register(nil, flow)
+		require.NoError(t, err)
+		assert.Equal(t, manager, flow.manager)
+		assert.Equal(t, flow, manager.flows["flow"])
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		err = manager.Register(flow)
+
+		var duplicateErr DuplicateFlowError
+		require.ErrorAs(t, err, &duplicateErr)
+		assert.Equal(t, "flow", duplicateErr.FlowID)
+	})
+}
+
+func TestManager_Middleware_StartAndRouteFlow(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	key := SessionKey{ChatID: 123, UserID: 456}
+
+	enteredName := 0
+	enteredAge := 0
+	completed := false
+
+	flow, err := New[testData]("registration").
+		Steps(
+			NewStep[testData]("name").
+				Enter(func(ctx *Context[testData]) error {
+					enteredName++
+					assert.Equal(t, "registration", ctx.FlowID())
+					assert.Equal(t, "name", ctx.StepID())
+					assert.Equal(t, key, ctx.SessionKey())
+					assert.Equal(t, int64(456), ctx.UserID())
+					assert.Equal(t, telego.ChatID{ID: 123}, ctx.ChatID())
+					assert.Equal(t, "/register", ctx.Text())
+					assert.NotNil(t, ctx.Message())
+					return nil
+				}).
+				Handle(func(ctx *Context[testData]) error {
+					ctx.Data().Name = ctx.Text()
+					return ctx.Go("age")
+				}, th.AnyMessageWithText()).
+				CanGo("age"),
+			NewStep[testData]("age").
+				Enter(func(ctx *Context[testData]) error {
+					enteredAge++
+					assert.Equal(t, "Alice", ctx.Data().Name)
+					return nil
+				}).
+				Handle(func(ctx *Context[testData]) error {
+					ctx.Data().Count++
+					return ctx.Complete()
+				}, th.TextEqual("done")),
+		).
+		OnComplete(func(ctx *Context[testData]) error {
+			completed = true
+			assert.Equal(t, "Alice", ctx.Data().Name)
+			assert.Equal(t, 1, ctx.Data().Count)
+			return nil
+		}).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+
+	group := newTestGroup(manager, func(group *th.HandlerGroup) {
+		group.Handle(flow.Start, th.CommandEqual("register"))
+	})
+
+	require.NoError(t, handleUpdate(t, group, messageUpdate("/register")))
+	state, data, ok := loadData[testData](t, storage, key)
+	require.True(t, ok)
+	assert.Equal(t, "name", state.CurrentStep)
+	assert.Empty(t, data.Name)
+	assert.Equal(t, 1, enteredName)
+	assert.Equal(t, 0, enteredAge)
+
+	require.NoError(t, handleUpdate(t, group, messageUpdate("Alice")))
+	state, data, ok = loadData[testData](t, storage, key)
+	require.True(t, ok)
+	assert.Equal(t, "age", state.CurrentStep)
+	assert.Equal(t, "Alice", data.Name)
+	assert.Equal(t, 1, enteredAge)
+
+	require.NoError(t, handleUpdate(t, group, messageUpdate("ignored")))
+	state, data, ok = loadData[testData](t, storage, key)
+	require.True(t, ok)
+	assert.Equal(t, "age", state.CurrentStep)
+	assert.Equal(t, 0, data.Count)
+	assert.False(t, completed)
+
+	require.NoError(t, handleUpdate(t, group, messageUpdate("done")))
+	_, _, ok = loadData[testData](t, storage, key)
+	assert.False(t, ok)
+	assert.True(t, completed)
+}
+
+func TestManager_Middleware_NoSessionCallsNext(t *testing.T) {
+	manager := NewManager(NewMemoryStorage())
+	called := false
+	group := newTestGroup(manager, func(group *th.HandlerGroup) {
+		group.Handle(func(_ *th.Context, update telego.Update) error {
+			called = true
+			assert.Equal(t, "hello", update.Message.Text)
+			return nil
+		}, th.AnyMessageWithText())
+	})
+
+	require.NoError(t, handleUpdate(t, group, messageUpdate("hello")))
+	assert.True(t, called)
+}
+
+func TestManager_Middleware_NoKeyCallsNext(t *testing.T) {
+	manager := NewManager(NewMemoryStorage())
+	called := false
+	group := newTestGroup(manager, func(group *th.HandlerGroup) {
+		group.Handle(func(_ *th.Context, update telego.Update) error {
+			called = true
+			assert.NotNil(t, update.Poll)
+			return nil
+		})
+	})
+
+	require.NoError(t, handleUpdate(t, group, telego.Update{Poll: &telego.Poll{ID: "poll"}}))
+	assert.True(t, called)
+}
+
+func TestManager_ActiveSession(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	manager.nowFunc = fixedNow
+	key := SessionKey{ChatID: 123, UserID: 456}
+
+	info, ok, err := manager.ActiveSession(&th.Context{}, messageUpdate("hello"))
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, info)
+
+	state := &SessionState{
+		Key:         key,
+		FlowID:      "flow",
+		CurrentStep: "step",
+		Data:        json.RawMessage(`{}`),
+		CreatedAt:   fixedNow(),
+		UpdatedAt:   fixedNow(),
+	}
+	require.NoError(t, storage.SaveSession(t.Context(), state))
+
+	info, ok, err = manager.ActiveSession(&th.Context{}, messageUpdate("hello"))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, info)
+	assert.Equal(t, key, info.Key)
+	assert.Equal(t, "flow", info.FlowID)
+	assert.Equal(t, "step", info.CurrentStep)
+
+	expiresAt := fixedNow().Add(-time.Second)
+	state.ExpiresAt = &expiresAt
+	require.NoError(t, storage.SaveSession(t.Context(), state))
+
+	info, ok, err = manager.ActiveSession(&th.Context{}, messageUpdate("hello"))
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, info)
+}
+
+func TestManager_Cancel(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	cancelCalled := false
+	key := SessionKey{ChatID: 123, UserID: 456}
+
+	flow, err := New[testData]("flow").
+		Steps(NewStep[testData]("start")).
+		OnCancel(func(ctx *Context[testData]) error {
+			cancelCalled = true
+			assert.Equal(t, "saved", ctx.Data().Name)
+			return nil
+		}).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+
+	data, err := json.Marshal(testData{Name: "saved"})
+	require.NoError(t, err)
+	require.NoError(t, storage.SaveSession(t.Context(), &SessionState{
+		Key:         key,
+		FlowID:      "flow",
+		CurrentStep: "start",
+		Data:        data,
+	}))
+
+	require.NoError(t, manager.Cancel(&th.Context{}, messageUpdate("/cancel")))
+	_, _, ok := loadData[testData](t, storage, key)
+	assert.False(t, ok)
+	assert.True(t, cancelCalled)
+}
+
+func TestManager_CancelErrors(t *testing.T) {
+	t.Run("no_key", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		err := manager.Cancel(&th.Context{}, telego.Update{Poll: &telego.Poll{ID: "poll"}})
+
+		var keyErr NoSessionKeyError
+		require.ErrorAs(t, err, &keyErr)
+	})
+
+	t.Run("no_session", func(t *testing.T) {
+		manager := NewManager(NewMemoryStorage())
+		require.NoError(t, manager.Cancel(&th.Context{}, messageUpdate("/cancel")))
+	})
+
+	t.Run("unknown_flow", func(t *testing.T) {
+		storage := NewMemoryStorage()
+		manager := NewManager(storage)
+		require.NoError(t, storage.SaveSession(t.Context(), &SessionState{
+			Key:    SessionKey{ChatID: 123, UserID: 456},
+			FlowID: "missing",
+			Data:   json.RawMessage(`{}`),
+		}))
+
+		err := manager.Cancel(&th.Context{}, messageUpdate("/cancel"))
+
+		var flowErr FlowNotFoundError
+		require.ErrorAs(t, err, &flowErr)
+		assert.Equal(t, "missing", flowErr.FlowID)
+	})
+}
+
+func TestManager_Timeout(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	manager.nowFunc = fixedNow
+	timeoutCalled := false
+	key := SessionKey{ChatID: 123, UserID: 456}
+
+	flow, err := New[testData]("flow").
+		Steps(NewStep[testData]("start")).
+		WithTimeout(time.Minute).
+		OnTimeout(func(ctx *Context[testData]) error {
+			timeoutCalled = true
+			assert.Equal(t, "old", ctx.Data().Name)
+			return nil
+		}).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+
+	data, err := json.Marshal(testData{Name: "old"})
+	require.NoError(t, err)
+	expiresAt := fixedNow().Add(-time.Second)
+	require.NoError(t, storage.SaveSession(t.Context(), &SessionState{
+		Key:         key,
+		FlowID:      "flow",
+		CurrentStep: "start",
+		Data:        data,
+		ExpiresAt:   &expiresAt,
+	}))
+
+	group := newTestGroup(manager)
+	require.NoError(t, handleUpdate(t, group, messageUpdate("hello")))
+
+	_, _, ok := loadData[testData](t, storage, key)
+	assert.False(t, ok)
+	assert.True(t, timeoutCalled)
+}
+
+func TestManager_StorageErrors(t *testing.T) {
+	t.Run("middleware_load_error", func(t *testing.T) {
+		storage := newPersistentTestStorage()
+		storage.loadErr = errTest
+		manager := NewManager(storage)
+		group := newTestGroup(manager)
+
+		err := handleUpdate(t, group, messageUpdate("hello"))
+
+		require.ErrorIs(t, err, errTest)
+	})
+
+	t.Run("start_save_error", func(t *testing.T) {
+		storage := newPersistentTestStorage()
+		storage.saveErr = errTest
+		manager := NewManager(storage)
+		flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+		require.NoError(t, err)
+		require.NoError(t, manager.Register(flow))
+
+		err = flow.Start(&th.Context{}, messageUpdate("/start"))
+
+		require.ErrorIs(t, err, errTest)
+	})
+
+	t.Run("complete_delete_error", func(t *testing.T) {
+		storage := newPersistentTestStorage()
+		storage.deleteErr = errTest
+		manager := NewManager(storage)
+		flow, err := New[testData]("flow").
+			Steps(NewStep[testData]("start").Enter(func(ctx *Context[testData]) error {
+				return ctx.Complete()
+			})).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, manager.Register(flow))
+
+		err = flow.Start(&th.Context{}, messageUpdate("/start"))
+
+		require.ErrorIs(t, err, errTest)
+	})
+}
+
+func TestManager_PersistentStorageRestoresAcrossManagers(t *testing.T) {
+	storage := newPersistentTestStorage()
+	key := SessionKey{ChatID: 123, UserID: 456}
+
+	firstManager := NewManager(storage)
+	firstFlow, err := New[testData]("flow").
+		Steps(
+			NewStep[testData]("name").
+				Handle(func(ctx *Context[testData]) error {
+					ctx.Data().Name = ctx.Text()
+					return ctx.Go("count")
+				}, th.AnyMessageWithText()).
+				CanGo("count"),
+			NewStep[testData]("count").
+				Enter(func(ctx *Context[testData]) error {
+					ctx.Data().Count++
+					return nil
+				}),
+		).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, firstManager.Register(firstFlow))
+
+	group := newTestGroup(firstManager, func(group *th.HandlerGroup) {
+		group.Handle(firstFlow.Start, th.CommandEqual("start"))
+	})
+	require.NoError(t, handleUpdate(t, group, messageUpdate("/start")))
+	require.NoError(t, handleUpdate(t, group, messageUpdate("Alice")))
+
+	state, data, ok := loadData[testData](t, storage, key)
+	require.True(t, ok)
+	assert.Equal(t, "count", state.CurrentStep)
+	assert.Equal(t, "Alice", data.Name)
+	assert.Equal(t, 1, data.Count)
+
+	secondManager := NewManager(storage)
+	secondEntered := false
+	secondFlow, err := New[testData]("flow").
+		Steps(
+			NewStep[testData]("name").CanGo("count"),
+			NewStep[testData]("count").
+				Handle(func(ctx *Context[testData]) error {
+					secondEntered = true
+					assert.Equal(t, "Alice", ctx.Data().Name)
+					assert.Equal(t, 1, ctx.Data().Count)
+					ctx.Data().Count++
+					return ctx.Complete()
+				}, th.TextEqual("finish")),
+		).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, secondManager.Register(secondFlow))
+
+	secondGroup := newTestGroup(secondManager)
+	require.NoError(t, handleUpdate(t, secondGroup, messageUpdate("finish")))
+
+	_, _, ok = loadData[testData](t, storage, key)
+	assert.False(t, ok)
+	assert.True(t, secondEntered)
+}
+
+func TestManager_ConcurrentUpdatesSameSessionAreSerialized(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var running atomic.Int32
+	var maxRunning atomic.Int32
+	var handled atomic.Int32
+
+	flow, err := New[testData]("flow").
+		Steps(NewStep[testData]("step").Handle(func(ctx *Context[testData]) error {
+			current := running.Add(1)
+			for {
+				currentMax := maxRunning.Load()
+				if current <= currentMax || maxRunning.CompareAndSwap(currentMax, current) {
+					break
+				}
+			}
+			if handled.Add(1) == 1 {
+				close(started)
+				<-release
+			}
+			ctx.Data().Count++
+			running.Add(-1)
+			return nil
+		})).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+	require.NoError(t, flow.Start(&th.Context{}, messageUpdate("/start")))
+
+	group := newTestGroup(manager)
+	bot := newTestBot(t)
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+
+	go func() { firstDone <- group.HandleUpdate(context.Background(), bot, messageUpdate("first")) }()
+	<-started
+	go func() { secondDone <- group.HandleUpdate(context.Background(), bot, messageUpdate("second")) }()
+
+	select {
+	case <-time.After(20 * time.Millisecond):
+		assert.Equal(t, int32(1), handled.Load())
+		assert.Equal(t, int32(1), maxRunning.Load())
+	case err := <-secondDone:
+		t.Fatalf("second update finished before first was released: %v", err)
+	}
+
+	close(release)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+	assert.Equal(t, int32(2), handled.Load())
+	assert.Equal(t, int32(1), maxRunning.Load())
+
+	_, data, ok := loadData[testData](t, storage, SessionKey{ChatID: 123, UserID: 456})
+	require.True(t, ok)
+	assert.Equal(t, 2, data.Count)
+}
+
+func TestManager_ConcurrentUpdatesDifferentSessionsRunInParallel(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var running atomic.Int32
+	var maxRunning atomic.Int32
+
+	flow, err := New[testData]("flow").
+		Steps(NewStep[testData]("step").Handle(func(ctx *Context[testData]) error {
+			current := running.Add(1)
+			for {
+				currentMax := maxRunning.Load()
+				if current <= currentMax || maxRunning.CompareAndSwap(currentMax, current) {
+					break
+				}
+			}
+			started <- struct{}{}
+			<-release
+			ctx.Data().Count++
+			running.Add(-1)
+			return nil
+		})).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+	require.NoError(t, flow.Start(&th.Context{}, messageUpdateFor(123, 456, "/start")))
+	require.NoError(t, flow.Start(&th.Context{}, messageUpdateFor(999, 789, "/start")))
+
+	group := newTestGroup(manager)
+	bot := newTestBot(t)
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+	go func() {
+		firstDone <- group.HandleUpdate(context.Background(), bot, messageUpdateFor(123, 456, "first"))
+	}()
+	go func() {
+		secondDone <- group.HandleUpdate(context.Background(), bot, messageUpdateFor(999, 789, "second"))
+	}()
+
+	<-started
+	<-started
+	assert.Equal(t, int32(2), maxRunning.Load())
+	close(release)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+}
+
+func TestManager_CustomKeyFunc(t *testing.T) {
+	storage := NewMemoryStorage()
+	manager := NewManager(storage, WithKeyFunc(func(update telego.Update) (SessionKey, bool) {
+		if update.Message == nil {
+			return SessionKey{}, false
+		}
+		return SessionKey{ChatID: 1, UserID: 2}, true
+	}))
+	flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+
+	require.NoError(t, flow.Start(&th.Context{}, messageUpdate("/start")))
+	_, _, ok := loadData[testData](t, storage, SessionKey{ChatID: 1, UserID: 2})
+	assert.True(t, ok)
+}
+
+func TestManager_HandleUnknownFlowAndBadData(t *testing.T) {
+	t.Run("unknown_flow", func(t *testing.T) {
+		storage := NewMemoryStorage()
+		manager := NewManager(storage)
+		require.NoError(t, storage.SaveSession(t.Context(), &SessionState{
+			Key:    SessionKey{ChatID: 123, UserID: 456},
+			FlowID: "missing",
+			Data:   json.RawMessage(`{}`),
+		}))
+
+		err := handleUpdate(t, newTestGroup(manager), messageUpdate("hello"))
+
+		var flowErr FlowNotFoundError
+		require.ErrorAs(t, err, &flowErr)
+		assert.Equal(t, "missing", flowErr.FlowID)
+	})
+
+	t.Run("bad_json", func(t *testing.T) {
+		storage := NewMemoryStorage()
+		manager := NewManager(storage)
+		flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+		require.NoError(t, err)
+		require.NoError(t, manager.Register(flow))
+		require.NoError(t, storage.SaveSession(t.Context(), &SessionState{
+			Key:         SessionKey{ChatID: 123, UserID: 456},
+			FlowID:      "flow",
+			CurrentStep: "start",
+			Data:        json.RawMessage(`{bad`),
+		}))
+
+		err = handleUpdate(t, newTestGroup(manager), messageUpdate("hello"))
+
+		var dataErr SessionDataError
+		require.ErrorAs(t, err, &dataErr)
+		assert.Equal(t, "flow", dataErr.FlowID)
+	})
+}
+
+func TestManager_ContextCancellationPassedToStorage(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	storage := NewMemoryStorage()
+	manager := NewManager(storage)
+	flow, err := New[testData]("flow").Steps(NewStep[testData]("start")).Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.Register(flow))
+
+	base := (&th.Context{}).WithContext(ctx)
+	err = flow.Start(base, messageUpdate("/start"))
+
+	// MemoryStorage doesn't reject canceled contexts, but this verifies the public
+	// path accepts a telegohandler context carrying arbitrary cancellation state.
+	require.NoError(t, err)
+}
+
+func TestManager_ErrorTypeFormatting(t *testing.T) {
+	assert.Equal(t, "telego: flow session key not found in update", (NoSessionKeyError{}).Error())
+	assert.Contains(t, (FlowNotFoundError{FlowID: "f"}).Error(), "f")
+	assert.Contains(t, (DuplicateFlowError{FlowID: "f"}).Error(), "f")
+	assert.Contains(t, (FlowNotRegisteredError{FlowID: "f"}).Error(), "f")
+	assert.Contains(t, (StepNotFoundError{FlowID: "f", StepID: "s"}).Error(), "s")
+	assert.Contains(t, (DuplicateStepError{StepID: "s"}).Error(), "s")
+	assert.Contains(t, (InvalidStartStepError{FlowID: "f", StepID: "s"}).Error(), "s")
+	assert.Contains(t, (InvalidTransitionError{FlowID: "f", From: "a", To: "b"}).Error(), "b")
+	assert.Contains(t, (TransitionNotAllowedError{FlowID: "f", From: "a", To: "b"}).Error(), "not allowed")
+	assert.Contains(t, (SessionDataError{FlowID: "f", Err: errTest}).Error(), "test error")
+	assert.ErrorIs(t, (SessionDataError{FlowID: "f", Err: errTest}).Unwrap(), errTest)
+}

--- a/telegoflow/memory_storage.go
+++ b/telegoflow/memory_storage.go
@@ -1,0 +1,70 @@
+package telegoflow
+
+import (
+	"context"
+	"sync"
+)
+
+// MemoryStorage stores sessions in memory.
+//
+// It is safe for concurrent use and useful for tests, examples, and bots that
+// don't need to survive process restarts.
+type MemoryStorage struct {
+	mu       sync.RWMutex
+	sessions map[SessionKey]*SessionState
+}
+
+// NewMemoryStorage creates an in-memory session storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		sessions: make(map[SessionKey]*SessionState),
+	}
+}
+
+// LoadSession loads a session by key.
+func (s *MemoryStorage) LoadSession(_ context.Context, key SessionKey) (*SessionState, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	session, ok := s.sessions[key]
+	if !ok {
+		return nil, false, nil
+	}
+
+	return cloneSession(session), true, nil
+}
+
+// SaveSession creates or replaces a session.
+func (s *MemoryStorage) SaveSession(_ context.Context, session *SessionState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.sessions[session.Key] = cloneSession(session)
+	return nil
+}
+
+// DeleteSession removes a session by key.
+func (s *MemoryStorage) DeleteSession(_ context.Context, key SessionKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.sessions, key)
+	return nil
+}
+
+func cloneSession(session *SessionState) *SessionState {
+	if session == nil {
+		return nil
+	}
+
+	clone := *session
+	if session.Data != nil {
+		clone.Data = append([]byte(nil), session.Data...)
+	}
+	if session.ExpiresAt != nil {
+		expiresAt := *session.ExpiresAt
+		clone.ExpiresAt = &expiresAt
+	}
+
+	return &clone
+}

--- a/telegoflow/session.go
+++ b/telegoflow/session.go
@@ -1,0 +1,62 @@
+package telegoflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// SessionKey identifies a single conversation session.
+//
+// The default key uses both chat ID and user ID, so the same user can have
+// independent conversations in private chats and groups.
+type SessionKey struct {
+	ChatID int64 `json:"chat_id"`
+	UserID int64 `json:"user_id"`
+}
+
+// String returns a stable textual representation of the session key.
+func (k SessionKey) String() string {
+	return fmt.Sprintf("%d:%d", k.ChatID, k.UserID)
+}
+
+// SessionState contains persistent session metadata and encoded typed data.
+type SessionState struct {
+	Key         SessionKey      `json:"key"`
+	FlowID      string          `json:"flow_id"`
+	CurrentStep string          `json:"current_step"`
+	Data        json.RawMessage `json:"data"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+	ExpiresAt   *time.Time      `json:"expires_at,omitempty"`
+}
+
+// Expired reports whether the session has passed its expiration time.
+func (s *SessionState) Expired(now time.Time) bool {
+	return s != nil && s.ExpiresAt != nil && now.After(*s.ExpiresAt)
+}
+
+// SessionInfo contains non-generic information about an active session.
+type SessionInfo struct {
+	Key         SessionKey
+	FlowID      string
+	CurrentStep string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	ExpiresAt   *time.Time
+}
+
+func newSessionInfo(state *SessionState) *SessionInfo {
+	if state == nil {
+		return nil
+	}
+
+	return &SessionInfo{
+		Key:         state.Key,
+		FlowID:      state.FlowID,
+		CurrentStep: state.CurrentStep,
+		CreatedAt:   state.CreatedAt,
+		UpdatedAt:   state.UpdatedAt,
+		ExpiresAt:   state.ExpiresAt,
+	}
+}

--- a/telegoflow/step.go
+++ b/telegoflow/step.go
@@ -1,0 +1,104 @@
+package telegoflow
+
+import (
+	"context"
+
+	"github.com/mymmrac/telego"
+	th "github.com/mymmrac/telego/telegohandler"
+)
+
+// Handler handles a flow step or lifecycle event.
+type Handler[T any] func(ctx *Context[T]) error
+
+// ErrorHandler handles an error returned by a step handler.
+type ErrorHandler[T any] func(ctx *Context[T], err error) error
+
+// Middleware wraps a flow handler.
+type Middleware[T any] func(next Handler[T]) Handler[T]
+
+type stepRoute[T any] struct {
+	predicates []th.Predicate
+	handler    Handler[T]
+}
+
+func (r stepRoute[T]) match(ctx context.Context, update telego.Update) bool {
+	for _, predicate := range r.predicates {
+		if !predicate(ctx, update) {
+			return false
+		}
+	}
+	return true
+}
+
+// Step represents one state in a conversation flow.
+type Step[T any] struct {
+	id          string
+	enter       Handler[T]
+	routes      []stepRoute[T]
+	fallback    Handler[T]
+	middlewares []Middleware[T]
+	canGo       map[string]struct{}
+}
+
+// NewStep creates a step with the provided ID.
+func NewStep[T any](id string) *Step[T] {
+	return &Step[T]{
+		id:    id,
+		canGo: make(map[string]struct{}),
+	}
+}
+
+// ID returns the step ID.
+func (s *Step[T]) ID() string {
+	if s == nil {
+		return ""
+	}
+	return s.id
+}
+
+// Enter sets a handler that is executed when the session enters this step.
+func (s *Step[T]) Enter(handler Handler[T]) *Step[T] {
+	s.enter = handler
+	return s
+}
+
+// Handle adds an input route to the step.
+//
+// When all predicates match, the route handler is executed. Routes are checked
+// in the order they were added. If no predicates are provided, the route matches
+// any update.
+func (s *Step[T]) Handle(handler Handler[T], predicates ...th.Predicate) *Step[T] {
+	s.routes = append(s.routes, stepRoute[T]{
+		predicates: predicates,
+		handler:    handler,
+	})
+	return s
+}
+
+// Fallback sets a handler that is executed when no input route matches.
+func (s *Step[T]) Fallback(handler Handler[T]) *Step[T] {
+	s.fallback = handler
+	return s
+}
+
+// Use adds middleware for this step.
+func (s *Step[T]) Use(middlewares ...Middleware[T]) *Step[T] {
+	s.middlewares = append(s.middlewares, middlewares...)
+	return s
+}
+
+// CanGo declares controlled transitions allowed from this step.
+func (s *Step[T]) CanGo(stepIDs ...string) *Step[T] {
+	if s.canGo == nil {
+		s.canGo = make(map[string]struct{}, len(stepIDs))
+	}
+	for _, stepID := range stepIDs {
+		s.canGo[stepID] = struct{}{}
+	}
+	return s
+}
+
+func (s *Step[T]) allows(stepID string) bool {
+	_, ok := s.canGo[stepID]
+	return ok
+}

--- a/telegoflow/step.go
+++ b/telegoflow/step.go
@@ -38,6 +38,7 @@ type Step[T any] struct {
 	fallback    Handler[T]
 	middlewares []Middleware[T]
 	canGo       map[string]struct{}
+	canComplete bool
 }
 
 // NewStep creates a step with the provided ID.
@@ -95,6 +96,15 @@ func (s *Step[T]) CanGo(stepIDs ...string) *Step[T] {
 	for _, stepID := range stepIDs {
 		s.canGo[stepID] = struct{}{}
 	}
+	return s
+}
+
+// CanComplete declares that this step can complete the flow.
+//
+// Context.Complete is still allowed from any handler; this declaration is used
+// by Flow.Graph to show the intended flow exit explicitly.
+func (s *Step[T]) CanComplete() *Step[T] {
+	s.canComplete = true
 	return s
 }
 

--- a/telegoflow/storage.go
+++ b/telegoflow/storage.go
@@ -1,0 +1,18 @@
+package telegoflow
+
+import "context"
+
+// Storage persists flow sessions.
+//
+// Storage implementations don't need to know the concrete generic data type of
+// a flow. Flow data is stored as JSON in [SessionState.Data].
+type Storage interface {
+	// LoadSession loads a session by key. The bool result is false when no session exists.
+	LoadSession(ctx context.Context, key SessionKey) (*SessionState, bool, error)
+
+	// SaveSession creates or replaces a session.
+	SaveSession(ctx context.Context, session *SessionState) error
+
+	// DeleteSession removes a session by key.
+	DeleteSession(ctx context.Context, key SessionKey) error
+}

--- a/telegoflow/test_helpers_test.go
+++ b/telegoflow/test_helpers_test.go
@@ -1,0 +1,152 @@
+package telegoflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mymmrac/telego"
+	th "github.com/mymmrac/telego/telegohandler"
+)
+
+const testToken = "1234567890:aaaabbbbaaaabbbbaaaabbbbaaaabbbbccc"
+
+var errTest = errors.New("test error")
+
+type testData struct {
+	Name  string `json:"name,omitempty"`
+	Count int    `json:"count,omitempty"`
+}
+
+type persistentTestStorage struct {
+	mu        sync.RWMutex
+	sessions  map[SessionKey][]byte
+	loadErr   error
+	saveErr   error
+	deleteErr error
+}
+
+func newPersistentTestStorage() *persistentTestStorage {
+	return &persistentTestStorage{sessions: make(map[SessionKey][]byte)}
+}
+
+func (s *persistentTestStorage) LoadSession(_ context.Context, key SessionKey) (*SessionState, bool, error) {
+	if s.loadErr != nil {
+		return nil, false, s.loadErr
+	}
+
+	s.mu.RLock()
+	data, ok := s.sessions[key]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, false, nil
+	}
+
+	var session SessionState
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, false, err
+	}
+	return &session, true, nil
+}
+
+func (s *persistentTestStorage) SaveSession(_ context.Context, session *SessionState) error {
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.sessions[session.Key] = data
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *persistentTestStorage) DeleteSession(_ context.Context, key SessionKey) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+
+	s.mu.Lock()
+	delete(s.sessions, key)
+	s.mu.Unlock()
+	return nil
+}
+
+func newTestBot(t *testing.T) *telego.Bot {
+	t.Helper()
+
+	bot, err := telego.NewBot(testToken)
+	require.NoError(t, err)
+	return bot
+}
+
+func newTestGroup(manager *Manager, handlers ...func(group *th.HandlerGroup)) *th.HandlerGroup {
+	group := &th.HandlerGroup{}
+	group.Use(manager.Middleware())
+	for _, handler := range handlers {
+		handler(group)
+	}
+	return group
+}
+
+func handleUpdate(t *testing.T, group *th.HandlerGroup, update telego.Update) error {
+	t.Helper()
+	return group.HandleUpdate(t.Context(), newTestBot(t), update)
+}
+
+func messageUpdate(text string) telego.Update {
+	return messageUpdateFor(123, 456, text)
+}
+
+func messageUpdateFor(chatID int64, userID int64, text string) telego.Update {
+	return telego.Update{
+		UpdateID: int(userID),
+		Message: &telego.Message{
+			MessageID: 10,
+			From:      &telego.User{ID: userID, FirstName: "Test"},
+			Chat:      telego.Chat{ID: chatID, Type: telego.ChatTypePrivate},
+			Text:      text,
+		},
+	}
+}
+
+func callbackUpdate(data string) telego.Update {
+	return telego.Update{
+		UpdateID: 2,
+		CallbackQuery: &telego.CallbackQuery{
+			ID:   "callback-id",
+			From: telego.User{ID: 456, FirstName: "Test"},
+			Message: &telego.Message{
+				MessageID: 10,
+				Chat:      telego.Chat{ID: 123, Type: telego.ChatTypePrivate},
+			},
+			Data: data,
+		},
+	}
+}
+
+func loadData[T any](t *testing.T, storage Storage, key SessionKey) (*SessionState, T, bool) {
+	t.Helper()
+
+	state, ok, err := storage.LoadSession(t.Context(), key)
+	require.NoError(t, err)
+	var data T
+	if !ok {
+		return nil, data, false
+	}
+	require.NoError(t, json.Unmarshal(state.Data, &data))
+	return state, data, true
+}
+
+func fixedNow() time.Time {
+	return time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+}


### PR DESCRIPTION
# :speech_balloon: Description

This PR adds `telegoflow`, an optional package for building multi-step Telegram bot conversations on top of `telegohandler`.

I based the idea on my older work in [Intele v2](https://github.com/nlypage/intele/tree/v2). I did not port it as-is. I took the parts that worked well there, mainly flows, steps, sessions, controlled navigation, and persistent state, then rewrote the API to fit Telego better.

The new package adds:

- typed flow data with Go generics;
- explicit step transitions through `CanGo(...)`, with validation during `Build()`;
- a `Manager` that plugs into `telegohandler` as middleware;
- a small `Storage` interface for persistent sessions, plus in-memory storage for tests and simple bots;
- per-session locking, so concurrent updates from the same user do not race the same flow state;
- lifecycle hooks for complete, cancel, timeout, and errors;
- `Flow.Graph()` for a readable text view of the flow graph;
- a new `examples/flow_conversation_bot` example using inline buttons on the confirmation step.

Example graph output:

```text
flow registration (start: name)
name
└─> age
    ├─> email
    │   └─> confirm (terminal)
    └─> retry
        └─> age (cycle)
```

I also added a `replace github.com/mymmrac/telego => ..` line to `examples/go.mod` with a comment. The examples module depends on the latest released Telego version, which does not contain `telegoflow` yet, so the replace is needed for local example builds before the next release.

I'm open to discussing the feature set and API shape. This is a first version of the package, so if some names, defaults, or boundaries feel off, I'm happy to adjust them before merge.

`telegoflow` coverage is 96.7%.

## :monocle_face: Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (changes in comments, .md files or other docs)
- [ ] Test update (changes in existing test cases)

# :clipboard: Checklist

- [x] My code follows the [style guidelines](/docs/CONTRIBUTING.md#art-style-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] Feature or fix that I was working on is in "[releasable](/docs/CONTRIBUTING.md#always-releasable)" state
